### PR TITLE
feat(glarea): its children are 2D content drawn above the surface — a HUD over GL, on both backends

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,19 @@ no override-redirect staging (issue #4).
   before its tree (`_surfaces`, `hitSurface`). So a listener on the
   surface's `window` is a bug — ntk selects what a window is listened to
   for, and the event stops reaching the tree.
+- `src/gloverlay.js` — a `<glarea>`'s children: 2D content drawn above the
+  surface. Laid out in its box and living in the owning window's tree like
+  anyone's — its damage list, its event manager, its focus — but painted on
+  _panes_ stacked over the surface, from the owning window's frame and with
+  its damage (`_syncOverlays`/`_paintOverlays` in nodes/window/flush.js). A
+  pane is one transparent layer on Cocoa (`app.createOverlayPane`,
+  `src/cocoa/overlay.js`), which Core Animation composites with the frame,
+  and one opaque child window per region the children reach on X11: no
+  SHAPE, which the in-process server lacks, and no pixmap the size of the
+  surface to show a legend in its corner. Two traps. A pane selects no input,
+  because the pointer reaches the tree by propagation the way it does over
+  the surface. And a child of a surface must never be promoted on Cocoa
+  (`promotableNode`): its layer would land under the GL layer.
 - `src/foreignnodes.js` — `<foreign>`: another process's window, embedded.
   A second `drawn: false` node, over ntk's `XEmbedSocket` (docs/embedding.md).
   Three things here are not obvious and are commented at length. **Teardown is

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -1935,20 +1935,72 @@ display lists**: every immediate-mode vertex is a command on the wire, so a
 mesh re-sent per frame costs kilobytes per frame, while a compiled list
 costs one `CallList`.
 
-Layout treats it as a leaf: it is sized and positioned like any other node,
-and its X window follows that rect. The window is stacked above everything
-drawn in the parent, so 2D content cannot overlap it — a HUD needs a
-sibling `<popup>`.
+The surface is stacked above everything drawn in its window, so nothing the
+window paints can overlap it. **Its own children can: they are 2D content
+drawn above the surface.** Layout treats a `<glarea>` as a flex container
+like a `<box>` — it is sized and positioned like any node, its window follows
+that rect, and its children are laid out inside it and cut to its box: a
+legend in a corner, a toolbar along an edge, a label over the scene. They are
+ordinary nodes in every way but one. The window's own paint cannot reach
+above the surface, so they are painted on **panes** stacked over it, in the
+same frame and from the same damage as everything else.
+
+```jsx
+<glarea style={{ flexGrow: 1 }} clearColor="#0e1320" onDraw={drawMap}>
+  <box
+    style={{
+      position: 'absolute',
+      left: 12,
+      top: 12,
+      padding: 8,
+      backgroundColor: '#f4f5f8',
+    }}
+  >
+    <text>Legend</text>
+  </box>
+</glarea>
+```
+
+What a pane is depends on the backend, and so does what translucent means:
+
+|                      | Cocoa                                                                                                   | X11                                                                                                                                                                                                     |
+| -------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| a pane               | one transparent layer over the whole surface, above the GL layer                                        | one child window per region the children reach — each child's paint reach, overlapping ones merged — stacked directly above the surface's window                                                        |
+| translucency         | composited by Core Animation: a translucent fill, an antialiased edge or a shadow blends with the frame | none: a pane is opaque, and whatever a child leaves unpainted inside its region — a rounded corner, a translucent fill, text with no box behind it — shows the surface's `clearColor`, not the GL frame |
+| between the children | the GL frame                                                                                            | the GL frame                                                                                                                                                                                            |
+
+So on X11 give each child a background, and expect a translucent one to be
+tinted by the `clearColor` rather than to show the scene. X11 cannot do
+better without a compositor, and a compositor would not help: it blends
+top-level windows, not the children inside one. A region per child, rather
+than one window cut to shape with the SHAPE extension, keeps each pane as
+small as what it holds and works on servers without SHAPE.
+`useSupports('glOverlay')` says whether a connection draws a surface's
+children at all (both backends do).
+
+Limits worth knowing:
+
+- **Overlapping surfaces:** where two surfaces overlap, both overlays are
+  above both frames on the Cocoa backend, and stack by when each was made
+  on X11.
+- **Scroll panes:** a surface scrolled partly out of a scroll pane is not
+  clipped by it. Its window and its panes are real windows placed at its
+  rect.
+- **Promotion:** a child of the surface is never lifted onto a layer of its
+  own for an animation on the Cocoa backend. That layer would sit under the
+  surface. Its transitions run on the frame clock instead.
 
 **The pointer over the surface is the tree's**, on both backends, exactly
 as over a `<box>`: `onMouseDown`, `onMouseMove`, `onMouseUp`, `onClick` (a
 double click is `detail: 2`), `onContextMenu`, `onMouseEnter` and
-`onMouseLeave`, `:hover` and `:active`, and `onWheel` fire at the
-`<glarea>` and bubble to its ancestors; a press focuses the nearest
-focusable one, and `ev.capturePointer()` keeps a drag that wanders off the
-surface. The window's hit test knows the surface is on top — a point inside
-its rect lands on the `<glarea>`, not on whatever the tree has behind it —
-and `pointerEvents: 'none'` on it lets the pointer through to that instead.
+`onMouseLeave`, `:hover` and `:active`, and `onWheel` fire at the child
+under the pointer, or at the `<glarea>` between its children, and bubble to
+the ancestors. A press focuses the nearest focusable one, and
+`ev.capturePointer()` keeps a drag that wanders off the surface. The
+window's hit test knows the surface and its children are on top: a point
+inside the rect lands on them, not on whatever the tree has behind.
+`pointerEvents: 'none'` on the surface lets the pointer through to that
+instead.
 
 ```jsx
 <glarea
@@ -1978,9 +2030,10 @@ was the only way to hear a press over a surface before core delivered it;
 (`GlAreaNode.prototype.forwardsPointer` from `react-x11/node`, to ask
 without rendering), and is the switch for dropping such a listener.
 
-`onDraw` is the raw escape hatch; for a scene, put 3D elements inside
-(below) and let the renderer drive the GL. See `examples/viewer3d.jsx` for
-the raw form, and `@react-x11/components/three` for a scene graph.
+`onDraw` is the raw escape hatch, and a scene graph over it is
+`@react-x11/components/three`. See `examples/viewer3d.jsx` for the raw
+form, and `examples/labs/gl-overlay.jsx` for a surface with a HUD over it on
+both backends.
 
 ---
 
@@ -2042,9 +2095,10 @@ for another application to lose its window.
 Layout treats it as a leaf, and its X window follows that rect; every change
 also sends the client the synthetic ICCCM 4.1.5 `ConfigureNotify` with
 root-relative coordinates. Stacking is `<glarea>`'s: the child window sits
-above everything drawn in the parent, so 2D content cannot overlap it — an
+above everything drawn in the parent, so 2D content cannot overlap it — and
+unlike a `<glarea>`, `<foreign>` takes no children to draw over it, so an
 overlay belongs in a sibling `<popup>` — and pointer events over it are the
-client's. `<foreign>` takes no children.
+client's.
 
 Keyboard focus is where this element has a rule of its own: **while a
 `<foreign>` holds focus, the application's handlers see every key first and

--- a/docs/events.md
+++ b/docs/events.md
@@ -8,8 +8,9 @@ events dispatched over the drawn node tree with DOM-like semantics.
 1. **Hit test**: front-to-back walk of the stacking-ordered tree (zIndex,
    then document order), respecting `overflow` clipping and
    `pointerEvents="none"`. A `<glarea>` is asked first: its surface is
-   stacked above everything 2D in the window, so a point over one lands on
-   it ([elements.md](elements.md#glarea)).
+   stacked above everything 2D in the window, and its children above the
+   surface, so a point over one lands on the child under it or on the
+   `<glarea>` ([elements.md](elements.md#glarea)).
 2. **Capture phase**: `on<Event>Capture` handlers from the window down to
    the target.
 3. **Target + bubble phase**: `on<Event>` handlers from the target up.

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1457,10 +1457,12 @@ it, so a window that selects nothing hands the pointer over it to the window
 the tree lives in — which is how a `<glarea>`'s presses reach the tree — and
 one that selects `ButtonPress` keeps every press for itself. Select only
 what the element needs from the server, and remember that ntk selects
-whatever a window is listened to for. The owning window's hit test knows
-about `<glarea>` surfaces and asks them before the tree
-(`GlAreaNode.hitSurface`); it does not know about a registered element's
-window, so a point over one lands on whatever the tree has behind it.
+whatever a window is listened to for. The panes a `<glarea>`'s children are
+drawn on (`src/gloverlay.js`) select nothing for the same reason. The owning
+window's hit test knows about `<glarea>` surfaces and their children and
+asks them before the tree (`GlAreaNode.hitSurface`); it does not know about
+a registered element's window, so a point over one lands on whatever the
+tree has behind it.
 
 `ForeignNode` (`src/foreignnodes.js`) is the same shape with the stakes
 raised, and it is the one to read if your element touches a resource you did

--- a/docs/gl.md
+++ b/docs/gl.md
@@ -106,10 +106,27 @@ where round trips are the thing to avoid.
 
 The pointer over a surface is the tree's, on every backend: `onMouseDown`,
 `onMouseMove`, `onMouseUp`, `onClick`, `onWheel` and the rest fire at the
-`<glarea>` and bubble, with `ev.localX`/`localY` measured from its corner —
-which is what a scene picks with. Nothing needs to listen on the surface's
-own window, and nothing should: on X11 a listener there takes the event
-away from the tree ([elements.md](elements.md#glarea) says why).
+`<glarea>` — or at a child drawn over it (below) — and bubble, with
+`ev.localX`/`localY` measured from the target's corner, which is what a
+scene picks with. Nothing needs to listen on the surface's own window, and
+nothing should: on X11 a listener there takes the event away from the tree
+([elements.md](elements.md#glarea) says why).
+
+## 2D over the surface
+
+A `<glarea>`'s children are drawn above it — a legend, a toolbar, a label
+over the scene — laid out in its box and hit before it. They are ordinary
+elements. Core paints them on panes stacked over the surface, from the
+window's own frame. On the Cocoa backend Core Animation composites the
+panes with the GL frame, translucency and all. On X11 a pane is an opaque
+child window, so what a child leaves unpainted shows the surface's
+`clearColor` ([elements.md](elements.md#glarea) has the table).
+`useSupports('glOverlay')` asks whether a connection draws them;
+`examples/labs/gl-overlay.jsx` runs one on both backends.
+
+So a HUD is not GL's business: its text is set by the app's own text
+engine, its controls take their own input, and nothing is rasterized into a
+texture.
 
 ## When there is no surface at all
 

--- a/docs/glx.md
+++ b/docs/glx.md
@@ -118,8 +118,11 @@ replays the same protocol onto WebGL2.
 - Is there a depth-buffer-capable visual reachable via `GetVisualConfigs` on
   both XQuartz and Xvfb/llvmpipe?
 - Can a `<glarea>` be composited with 2D content drawn over it, or does the
-  GL child window always sit on top? (Likely always on top, so a HUD overlay
-  would need a sibling window.)
+  GL child window always sit on top? Answered: the GL window is always on
+  top of the parent's drawing, so the surface's own children are drawn on
+  windows of their own stacked above it — opaque ones, one per region they
+  reach, since a child window cannot be translucent without a compositor
+  (`src/gloverlay.js`, [elements.md](elements.md#glarea)).
 
 ## Scope discipline
 

--- a/examples/labs/gl-overlay.jsx
+++ b/examples/labs/gl-overlay.jsx
@@ -1,0 +1,382 @@
+// 2D over a GL surface — a <glarea>'s children, drawn above it — on a real
+// display.
+//
+//   npm run labs:gl-overlay
+//   REACT_X11_BACKEND=x11 npm run labs:gl-overlay       # X11 on macOS
+//   LAB_SHOT=/tmp/overlay.png npm run labs:gl-overlay   # one frame, then exit
+//
+// A surface drawing an equalizer, a frame at a time, with a HUD over it: a
+// title card, a legend, a row of buttons and a readout. None of the HUD is
+// GL. It is ordinary boxes and text, the children of the <glarea>, which core
+// lays out in the surface's box and draws above it (src/gloverlay.js).
+// Nothing in the suite can witness that composite — the in-process server
+// draws no GL at all, and window capture does not see a GL surface on either
+// backend (docs/glx.md) — so this is a lab: run it, and look.
+//
+// ## What to look at
+//
+// **The title card is translucent on the Cocoa backend and opaque on X11.**
+// It is the one difference between the backends, and the documented one
+// (docs/elements.md): Core Animation composites the overlay with the GL
+// frame, where an X11 child window cannot be translucent — so there the
+// card's half-transparent fill blends with the surface's `clearColor`, and
+// the bars stop at its edge.
+//
+// **The HUD takes the pointer; the surface takes the rest.** The buttons are
+// in the overlay. A drag anywhere else on the surface scrubs the bars — the
+// surface's own handlers, with `capturePointer()` so the scrub survives the
+// pointer leaving the window.
+//
+// **Hide the legend** and its pane goes; show it and a new one is painted.
+// The readout changes once a second, and repaints its own pane and nothing
+// else.
+//
+// ## LAB_SHOT
+//
+// One frame, reconstructed rather than captured: the GL frame read back with
+// `readPixels` inside `onDraw` — the only way there is to see a surface —
+// under the window's own pixels and the overlay's, composited the way the
+// backend composites them. It needs the direct backend, the one with a
+// synchronous `readPixels`: the Cocoa backend, or X11 under a direct `glPolicy`.
+// Where the server itself can show GL pixels — Xvfb with `+iglx` — `xwd
+// -root` captures the real composite instead.
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+import { Button, createRoot, createStyles, useApp } from '../../src/index.js';
+
+const BARS = 18;
+const shot = process.env.LAB_SHOT || null;
+// where LAB_SHOT's frame is drawn: bars 1-4 at 0.77-0.92 of the height
+const SHOT_PHASE = -0.08;
+
+/** A bar's colour: cool at the left, warm at the right. */
+function barColor(i) {
+  const t = i / (BARS - 1);
+  return [0.2 + 0.75 * t, 0.55 + 0.3 * Math.sin(t * Math.PI), 0.95 - 0.7 * t];
+}
+
+const css = ([r, g, b]) =>
+  `rgb(${Math.round(r * 255)}, ${Math.round(g * 255)}, ${Math.round(b * 255)})`;
+
+/** Where each bar is, in the surface's pixels, bottom-up the way GL counts. */
+function bars(width, height, phase) {
+  const slot = width / BARS;
+  const gap = Math.max(2, Math.round(slot / 6));
+  const out = [];
+  for (let i = 0; i < BARS; i++) {
+    // tall enough to pass under the title card: that is where the two
+    // backends' overlays look different
+    const level =
+      0.6 +
+      0.38 * Math.sin(phase + i * 0.55) * Math.cos(phase * 0.37 + i * 0.21);
+    out.push({
+      x: Math.round(i * slot + gap / 2),
+      width: Math.max(1, Math.round(slot - gap)),
+      height: Math.round(height * level),
+      color: barColor(i),
+    });
+  }
+  return out;
+}
+
+/**
+ * The frame, in whichever GL this connection has. The two backends are
+ * different APIs (docs/gl.md), and bars are the one picture both can draw
+ * without a shader: a scissored clear per bar on the direct backend, two
+ * triangles per bar in immediate mode on the indirect one, whose context has
+ * no scissor.
+ */
+function drawBars(gl, width, height, phase) {
+  const list = bars(width, height, phase);
+  if (gl.backend === 'direct') {
+    gl.enable(gl.SCISSOR_TEST);
+    for (const bar of list) {
+      gl.scissor(bar.x, 0, bar.width, bar.height);
+      gl.clearColor(...bar.color, 1);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+    }
+    gl.disable(gl.SCISSOR_TEST);
+    return;
+  }
+  // normalised device coordinates, the matrices left at identity
+  const nx = (x) => (x / width) * 2 - 1;
+  const ny = (y) => (y / height) * 2 - 1;
+  gl.MatrixMode(gl.PROJECTION);
+  gl.LoadIdentity();
+  gl.MatrixMode(gl.MODELVIEW);
+  gl.LoadIdentity();
+  gl.Begin(gl.TRIANGLES);
+  for (const bar of list) {
+    const x0 = nx(bar.x);
+    const x1 = nx(bar.x + bar.width);
+    const y0 = ny(0);
+    const y1 = ny(bar.height);
+    gl.Color3f(...bar.color);
+    gl.Vertex3f(x0, y0, 0);
+    gl.Vertex3f(x1, y0, 0);
+    gl.Vertex3f(x1, y1, 0);
+    gl.Vertex3f(x0, y0, 0);
+    gl.Vertex3f(x1, y1, 0);
+    gl.Vertex3f(x0, y1, 0);
+  }
+  gl.End();
+}
+
+/**
+ * LAB_SHOT: the display's composite, rebuilt from its three layers — the
+ * window's own pixels, the GL frame over the surface's rect, and the
+ * overlay's panes over that, alpha-blended the way the backend blends them
+ * (an X11 pane is opaque, so its alpha is one). Reaches into the overlay's
+ * panes, which is a lab's privilege: there is no public way to read them,
+ * and none is needed outside a picture like this one.
+ */
+async function writeShot(path, area, glPixels) {
+  const { writeFileSync } = await import('node:fs');
+  const { PNG } = await import('pngjs');
+  const wnd = area.root.window;
+  const width = wnd.width;
+  const height = wnd.height;
+  const png = new PNG({ width, height });
+  const own = await wnd.getContext('2d').getImageData(0, 0, width, height);
+  png.data.set(own.data.subarray(0, width * height * 4));
+  // readPixels is bottom-up, a PNG top-down
+  const r = area.rect;
+  for (let y = 0; y < r.height; y++) {
+    for (let x = 0; x < r.width; x++) {
+      const src = ((r.height - 1 - y) * r.width + x) * 4;
+      const dst = ((r.y + y) * width + (r.x + x)) * 4;
+      png.data[dst] = glPixels[src];
+      png.data[dst + 1] = glPixels[src + 1];
+      png.data[dst + 2] = glPixels[src + 2];
+    }
+  }
+  for (const pane of area._overlay?.panes ?? []) {
+    const p = pane.rect;
+    const img = await pane.context().getImageData(0, 0, p.width, p.height);
+    for (let y = 0; y < p.height; y++) {
+      for (let x = 0; x < p.width; x++) {
+        const src = (y * p.width + x) * 4;
+        const dst = ((p.y + y) * width + (p.x + x)) * 4;
+        const a = img.data[src + 3] / 255;
+        for (let c = 0; c < 3; c++) {
+          png.data[dst + c] = Math.round(
+            img.data[src + c] * a + png.data[dst + c] * (1 - a),
+          );
+        }
+      }
+    }
+  }
+  for (let i = 3; i < png.data.length; i += 4) png.data[i] = 255;
+  writeFileSync(path, PNG.sync.write(png));
+  console.log(
+    `wrote ${path} (${width}x${height}): the GL frame (readPixels) under ` +
+      'the window’s and the overlay’s own pixels — a reconstruction',
+  );
+}
+
+const s = createStyles({
+  stage: { flexGrow: 1 },
+  card: {
+    position: 'absolute',
+    left: 16,
+    top: 16,
+    width: 260,
+    padding: 12,
+    gap: 4,
+    borderRadius: 10,
+    backgroundColor: 'rgba(255, 255, 255, 0.55)',
+  },
+  title: { fontSize: 15, color: '#101420' },
+  note: { fontSize: 11, color: '#1d2438' },
+  legend: {
+    position: 'absolute',
+    right: 16,
+    top: 16,
+    padding: 10,
+    gap: 6,
+    borderRadius: 8,
+    backgroundColor: '#f4f5f8',
+  },
+  swatchRow: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  swatch: { width: 12, height: 12, borderRadius: 3 },
+  label: { fontSize: 11, color: '#1d2438' },
+  controls: {
+    position: 'absolute',
+    left: 16,
+    bottom: 16,
+    flexDirection: 'row',
+    gap: 8,
+    padding: 8,
+    borderRadius: 8,
+    backgroundColor: '#f4f5f8',
+  },
+  readout: {
+    position: 'absolute',
+    right: 16,
+    bottom: 16,
+    padding: 6,
+    borderRadius: 6,
+    backgroundColor: '#101420',
+  },
+  readoutText: { fontSize: 11, color: '#e8ecf6' },
+});
+
+function Stage() {
+  const app = useApp();
+  const [paused, setPaused] = useState(false);
+  const [speed, setSpeed] = useState(1);
+  const [legend, setLegend] = useState(true);
+  const [dragging, setDragging] = useState(false);
+  const [fps, setFps] = useState(0);
+  const clock = useRef({ phase: 0, last: null, frames: 0 });
+  const drag = useRef(null);
+  const area = useRef(null);
+  const shotTaken = useRef(false);
+  // The backend composites the overlay itself: the Cocoa backend's pane is a
+  // layer Core Animation blends with the frame (src/cocoa/overlay.js).
+  const composited = typeof app.createOverlayPane === 'function';
+
+  const onDraw = useCallback(
+    (gl, { width, height }) => {
+      const c = clock.current;
+      const now = performance.now();
+      if (c.last !== null && !paused) {
+        c.phase += ((now - c.last) / 1000) * 2.4 * speed;
+      }
+      c.last = now;
+      c.frames += 1;
+      // The shot's frame is drawn at one phase, the same every run, and one
+      // where the bars under the title card stand taller than the card's
+      // edge — the difference between the backends is only visible there.
+      const shotFrame = shot && !shotTaken.current && c.frames === 90;
+      drawBars(gl, width, height, shotFrame ? SHOT_PHASE : c.phase);
+      // synchronously, inside the frame: after it, readPixels reads nothing
+      if (shotFrame) {
+        shotTaken.current = true;
+        if (gl.backend !== 'direct') {
+          console.error('LAB_SHOT needs the direct backend — see the header');
+          process.exit(1);
+        }
+        const pixels = new Uint8Array(width * height * 4);
+        gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+        writeShot(shot, area.current, pixels).then(
+          () => process.exit(0),
+          (err) => {
+            console.error(err);
+            process.exit(1);
+          },
+        );
+      }
+    },
+    [paused, speed],
+  );
+
+  // the readout: once a second, a claim inside the overlay and nowhere else
+  useEffect(() => {
+    let frames = clock.current.frames;
+    let since = performance.now();
+    const timer = setInterval(() => {
+      const now = performance.now();
+      setFps(
+        Math.round(((clock.current.frames - frames) * 1000) / (now - since)),
+      );
+      frames = clock.current.frames;
+      since = now;
+    }, 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  // A press on the HUD bubbles through the surface too: only one on the
+  // surface itself starts a scrub.
+  const onMouseDown = useCallback((ev) => {
+    if (ev.target !== area.current) return;
+    ev.capturePointer();
+    drag.current = ev.x;
+    setDragging(true);
+  }, []);
+  const onMouseMove = useCallback((ev) => {
+    if (drag.current === null) return;
+    clock.current.phase += (ev.x - drag.current) * 0.02;
+    drag.current = ev.x;
+  }, []);
+  const onMouseUp = useCallback(() => {
+    drag.current = null;
+    setDragging(false);
+  }, []);
+
+  const togglePause = useCallback(() => {
+    // a resumed clock starts from now, not from when it stopped
+    clock.current.last = null;
+    setPaused((v) => !v);
+  }, []);
+
+  return (
+    <glarea
+      ref={area}
+      style={s.stage}
+      clearColor="#0e1320"
+      frameLoop={paused && !dragging ? 'demand' : 'always'}
+      onDraw={onDraw}
+      onMouseDown={onMouseDown}
+      onMouseMove={onMouseMove}
+      onMouseUp={onMouseUp}
+    >
+      <box style={s.card}>
+        <text style={s.title}>2D over a GL surface</text>
+        <text style={s.note}>
+          {composited
+            ? 'Composited: this card blends with the bars.'
+            : 'X11: an opaque pane, on the clear colour.'}
+        </text>
+        <text style={s.note}>Drag the bars to scrub them.</text>
+      </box>
+      {legend && (
+        <box style={s.legend}>
+          {['low', 'mid', 'high'].map((name, k) => (
+            <box key={name} style={s.swatchRow}>
+              <box
+                style={[s.swatch, { backgroundColor: css(barColor(k * 8.5)) }]}
+              />
+              <text style={s.label}>{name}</text>
+            </box>
+          ))}
+        </box>
+      )}
+      <box style={s.controls}>
+        <Button onPress={togglePause}>{paused ? 'Play' : 'Pause'}</Button>
+        <Button onPress={() => setSpeed((v) => (v >= 4 ? 1 : v * 2))}>
+          {`Speed ×${speed}`}
+        </Button>
+        <Button onPress={() => setLegend((v) => !v)}>
+          {legend ? 'Hide legend' : 'Show legend'}
+        </Button>
+      </box>
+      <box style={s.readout}>
+        <text style={s.readoutText}>{`${fps} fps`}</text>
+      </box>
+    </glarea>
+  );
+}
+
+export function App() {
+  return (
+    <window
+      width={720}
+      height={440}
+      title="2D over a GL surface"
+      wmClass="com.example.x11gloverlay"
+      style={{ flexGrow: 1, backgroundColor: '#0e1320' }}
+    >
+      <Stage />
+    </window>
+  );
+}
+
+export default App;
+
+if (!process.env.REACT_X11_NO_AUTORUN) {
+  // 'auto': direct where there is one, which LAB_SHOT needs, and indirect
+  // where there is not — Xvfb with +iglx
+  const root = await createRoot({ glPolicy: 'auto' });
+  root.render(<App />);
+}

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "examples:frame": "tsx examples/frame.jsx",
     "labs:text-baseline": "tsx examples/labs/text-baseline.jsx",
     "labs:direct-gl": "tsx examples/labs/direct-gl.jsx",
+    "labs:gl-overlay": "tsx examples/labs/gl-overlay.jsx",
     "examples:viewer3d": "tsx examples/viewer3d.jsx",
     "examples:transparent": "tsx examples/transparent.jsx",
     "examples:windows": "tsx examples/windows.jsx",

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -138,17 +138,18 @@ const HostConfig = {
     return {
       isInsideText: false,
       isInsideSvg: false,
-      isInside3d: false,
     };
   },
 
   getChildHostContext(parentHostContext, type) {
+    // A `<glarea>`'s children are drawn nodes like any box's — 2D content
+    // above the surface (src/gloverlay.js) — so it opens no context of its
+    // own. A scene graph over the surface is `@react-x11/components/three`,
+    // with a reconciler of its own.
     return {
       isInsideText: parentHostContext.isInsideText || type === 'text',
       // <svg> children are declarative SVG elements, not react-x11 nodes
       isInsideSvg: parentHostContext.isInsideSvg || type === 'svg',
-      // inside <glarea> the children are scene nodes, not drawn nodes
-      isInside3d: parentHostContext.isInside3d || type === 'glarea',
     };
   },
 
@@ -192,17 +193,6 @@ const HostConfig = {
       throw new Error(
         `react-x11: <${type}> is not allowed inside <text>; only nested ` +
           '<text> spans and strings are.',
-      );
-    }
-    if (hostContext.isInside3d) {
-      // `<glarea>` is a leaf here: it owns the surface, the frame clock and
-      // the swap, and `onDraw` is the escape hatch. A *scene graph* over it
-      // — meshes, materials, lights, post-processing, on either backend —
-      // is `@react-x11/components/three`, which brings its own reconciler.
-      throw new Error(
-        `react-x11: <${type}> is not an element — <glarea> takes no ` +
-          'children. Draw through `onDraw`, or use ' +
-          '`@react-x11/components/three` for a scene graph. See docs/gl.md.',
       );
     }
     let node;

--- a/src/appcontext.js
+++ b/src/appcontext.js
@@ -28,6 +28,7 @@ import {
 } from './compositing.js';
 import { canEmbed } from './embedding.js';
 import { hasDirectGL, watchDirectGL } from './glbackend.js';
+import { canOverlay } from './gloverlay.js';
 
 const AppContext = createContext(null);
 
@@ -58,9 +59,10 @@ export function useApp() {
   return app;
 }
 
-// 'nativeControls' and 'embedding' are properties of the backend, decided
-// before the first render and never changing after — so their subscription
-// has nothing to deliver and their snapshot is a property test.
+// 'nativeControls', 'embedding' and 'glOverlay' are properties of the
+// backend, decided before the first render and never changing after — so
+// their subscription has nothing to deliver and their snapshot is a property
+// test.
 const NEVER_CHANGES = () => () => {};
 
 // What `useSupports` watches and reads, per feature. `read` answers a
@@ -77,6 +79,7 @@ const FEATURES = {
     read: (app) => Boolean(app.nativeBezels),
   },
   embedding: { watch: NEVER_CHANGES, read: canEmbed },
+  glOverlay: { watch: NEVER_CHANGES, read: canOverlay },
 };
 
 /**
@@ -153,6 +156,20 @@ const FEATURES = {
  * ```
  *
  * Like `'nativeControls'`, it is a property of the backend and never changes.
+ *
+ * `'glOverlay'` is true when the children of a `<glarea>` are drawn above its
+ * GL surface on this connection — laid out in its box, painted on panes over
+ * the surface, hit before it. Both backends draw them; what differs is
+ * translucency, composited by Core Animation on the Cocoa backend and opaque
+ * on X11 (docs/elements.md says exactly how). It is the question to ask
+ * before handing a surface its HUD rather than drawing that some other way:
+ *
+ * ```jsx
+ * const overlay = useSupports('glOverlay');
+ * <glarea onDraw={drawMap}>{overlay && <Legend />}</glarea>
+ * ```
+ *
+ * A property of the backend too, and it never changes.
  */
 export function useSupports(feature) {
   const app = useApp();

--- a/src/cocoa/app.js
+++ b/src/cocoa/app.js
@@ -26,6 +26,7 @@ import { setScreensForTests } from '../screens.js';
 import { setScaleForTests } from '../scale.js';
 import { BezelStore } from './bezels.js';
 import { CocoaGLArea, cocoaGLConfig, resolveCocoaGLRuntime } from './glarea.js';
+import { CocoaOverlayPane } from './overlay.js';
 import { CocoaDockMenu } from './dock.js';
 import { CocoaGlobalMenuExport } from './globalmenu.js';
 import { CocoaStatusItem } from './statusitem.js';
@@ -416,6 +417,16 @@ export class CocoaApp {
    */
   chooseGLConfig(spec) {
     return cocoaGLConfig(this, spec);
+  }
+
+  /**
+   * The pane a `<glarea>`'s children are drawn on (src/gloverlay.js): one
+   * transparent layer above the surface's, which Core Animation composites —
+   * so the overlay blends with the GL frame here, where an X11 pane is an
+   * opaque child window. Having this at all is how the overlay knows.
+   */
+  createOverlayPane(attributes) {
+    return new CocoaOverlayPane(this, attributes);
   }
 
   /**

--- a/src/cocoa/overlay.js
+++ b/src/cocoa/overlay.js
@@ -1,0 +1,159 @@
+// The pane a `<glarea>`'s children are drawn on, on the Cocoa backend: a
+// transparent bitmap layer over the surface (src/gloverlay.js).
+//
+// A sublayer of the window's root layer like the surface's own
+// (src/cocoa/glarea.js), one step above it: the GL layer sits at zPosition
+// 1e7, over everything both presenters put on the root layer, and this one
+// at 1e7 + 1, over that. Core Animation composites it, so what the children
+// leave transparent shows the GL frame, and a translucent fill, an
+// antialiased edge or a shadow blends with it — the one backend where the
+// overlay is not opaque. Every surface's GL layer shares the one zPosition,
+// so where two surfaces overlap, both overlays are above both frames.
+//
+// It speaks the verbs of a window the overlay drives on X11 — `setState`,
+// `map`, `unmap`, `getContext`, `destroy` — plus `present`, which puts what
+// was painted on the layer: ntk blits an X window's backing store on its
+// own, where a layer's contents are a copy the bitmap has to be pushed to.
+import { CocoaContext2D } from './context2d.js';
+
+export const OVERLAY_Z = 1e7 + 1;
+
+export class CocoaOverlayPane {
+  constructor(app, options) {
+    this.app = app;
+    this.parent = options.parent;
+    this._native = app._native;
+    this.scale = this.parent.scale ?? app.scale ?? 1;
+    this.destroyed = false;
+    this.layer = this._native.createLayer();
+    this._native.addSublayer(this.parent._layer, this.layer);
+    this.rect = null;
+    this._surface = null;
+    this._surfaceSize = null;
+    this._gen = 0;
+    this._ctx = null;
+    this._dirty = false;
+    // Hidden until something is on it: a layer shows its contents from the
+    // moment it is added, and before the first present there are none to
+    // show, only whatever the render server makes of that.
+    this._presented = false;
+    this._hidden = false;
+    this.setState({
+      x: options.x ?? 0,
+      y: options.y ?? 0,
+      width: options.width ?? 1,
+      height: options.height ?? 1,
+    });
+  }
+
+  get width() {
+    return this.rect?.width ?? 0;
+  }
+
+  get height() {
+    return this.rect?.height ?? 0;
+  }
+
+  /** Geometry in device px, the unit the overlay's rects are in. */
+  setState(rect) {
+    if (this.destroyed) return;
+    this.rect = rect;
+    const s = this.scale;
+    this._setLayerProps({
+      frame: [rect.x / s, rect.y / s, rect.width / s, rect.height / s],
+      zPosition: OVERLAY_Z,
+      hidden: this._hidden || !this._presented,
+    });
+  }
+
+  map() {
+    this._hidden = false;
+    if (this._presented) this._setLayerProps({ hidden: false });
+  }
+
+  unmap() {
+    this._hidden = true;
+    this._setLayerProps({ hidden: true });
+  }
+
+  /** Implicit animations off, for the reason `CocoaGLArea._setLayerProps`
+   * gives: no frame's transaction covers a layer that is not a presenter's. */
+  _setLayerProps(props) {
+    if (this.destroyed) return;
+    const native = this._native;
+    native.txBegin({ disableActions: true });
+    try {
+      native.setLayerProps(this.layer, props);
+    } finally {
+      native.txCommit();
+    }
+  }
+
+  /** The bitmap, the pane's size — a new size is a new bitmap, cleared, and
+   * the old one freed now rather than by the handle's finalizer. */
+  _ensureSurface() {
+    const w = Math.max(1, this.rect?.width ?? 1);
+    const h = Math.max(1, this.rect?.height ?? 1);
+    const size = this._surfaceSize;
+    if (!this._surface || size.width !== w || size.height !== h) {
+      this._release();
+      this._surface = this._native.createSurface(w, h, this.scale);
+      this._native.ctxClearRect(this._surface, 0, 0, w, h);
+      this._surfaceSize = { width: w, height: h };
+      this._gen++;
+    }
+    return this._surface;
+  }
+
+  _release() {
+    const surface = this._surface;
+    this._surface = null;
+    if (surface && typeof this._native.releaseSurface === 'function') {
+      this._native.releaseSurface(surface);
+    }
+  }
+
+  getContext() {
+    if (!this._ctx) {
+      this._ctx = new CocoaContext2D(
+        this._native,
+        () => this._ensureSurface(),
+        () => {
+          this._ensureSurface();
+          return this._gen;
+        },
+      );
+      this._ctx._fonts = this.app.fonts;
+      this._ctx._onDirty = () => {
+        this._dirty = true;
+      };
+    }
+    return this._ctx;
+  }
+
+  /** What was painted, onto the layer — a copy, so the bitmap is free to be
+   * painted again at once. */
+  present() {
+    if (this.destroyed || !this._dirty || !this._surface) return;
+    this._dirty = false;
+    const native = this._native;
+    native.txBegin({ disableActions: true });
+    try {
+      native.surfaceToLayer(this._surface, this.layer);
+      if (!this._presented) {
+        this._presented = true;
+        if (!this._hidden) native.setLayerProps(this.layer, { hidden: false });
+      }
+    } finally {
+      native.txCommit();
+    }
+  }
+
+  destroy() {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    this._release();
+    this._ctx = null;
+    this._native.removeFromSuperlayer(this.layer);
+  }
+}

--- a/src/cocoa/promotion.js
+++ b/src/cocoa/promotion.js
@@ -143,6 +143,18 @@ function paintsSomething(node) {
 }
 
 /**
+ * Inside a `<glarea>`: drawn on a pane above the surface (src/gloverlay.js).
+ * A layer of its own would sit on the root layer *under* the GL layer, so a
+ * promoted node there would vanish behind the surface it is drawn over.
+ */
+function insideGlArea(node) {
+  for (let n = node.parent; n && !n.isWindow; n = n.parent) {
+    if (n.isGlArea) return true;
+  }
+  return false;
+}
+
+/**
  * Can this node be a property box on a layer at all — the static half of
  * the answer, the same whatever the scene around it does: a plain box by
  * its target style, not a scroller (its bars and clip host are the layer
@@ -150,6 +162,7 @@ function paintsSomething(node) {
  */
 function promotableNode(node) {
   if (node.destroyed || !plainBox(node)) return false;
+  if (insideGlArea(node)) return false;
   if (!stylePaintsPlain(node, node._targetStyle ?? node.style)) return false;
   if (node.isScroller?.()) return false;
   return !paintsOutline(node);

--- a/src/glnodes.js
+++ b/src/glnodes.js
@@ -10,6 +10,7 @@ import { cssColorStraight } from 'ntk';
 // re-exported so the GL element layer stays one import for consumers
 export { directGLFailure, hasDirectGL } from './glbackend.js';
 
+import { GlOverlay, canOverlay } from './gloverlay.js';
 import { Node } from './nodes/node.js';
 import { FramePacer, resolveFrameRate } from './pacing.js';
 
@@ -105,17 +106,22 @@ const px = (v) => Math.max(1, Math.round(v || 0));
  *   vocabulary as `<window frameRate>`. Defaults to the owning window's.
  * - `glx` — a `chooseGLXConfig` spec, e.g. `{ DEPTH_SIZE: 24 }`.
  *
- * The X child window is stacked above everything drawn in the parent, so 2D
- * content cannot overlap it — put HUD content in a sibling `<popup>`.
+ * The X child window is stacked above everything drawn in the parent, so the
+ * parent's 2D content cannot overlap it — but this node's own children do:
+ * they are laid out in its box like a `<box>`'s and drawn above the surface,
+ * on panes of their own (src/gloverlay.js).
  *
  * Pointer input over the surface is the tree's, on both backends: a press,
- * a drag or a wheel over it is a synthetic event *at this node*, bubbling
- * to its ancestors like anyone else's (`hitSurface` says how).
+ * a drag or a wheel over it is a synthetic event at the child under the
+ * pointer, or at this node, bubbling to its ancestors like anyone else's
+ * (`hitSurface` says how).
  */
 export class GlAreaNode extends Node {
   constructor(props, app) {
     super('glarea', props, app);
     this.window = null;
+    // the panes the children are drawn on, while there are children
+    this._overlay = null;
     this.gl = null;
     this.rect = null; // geometry last sent to the X window
     this._realizing = false;
@@ -154,9 +160,19 @@ export class GlAreaNode extends Node {
 
   _setRoot(root) {
     super._setRoot(root);
+    // Children mounted along with this node — React builds a subtree before
+    // it attaches it — are drawn from the first frame of the window it joins.
+    if (this.children.length) root?._overlaid?.add(this);
     // the owning window may already exist (a <glarea> mounted into a live
     // tree); otherwise WindowNode.realize picks the subtree up
     if (root?.window) this.realize();
+  }
+
+  insertBefore(child, beforeChild) {
+    super.insertBefore(child, beforeChild);
+    // 2D content above the surface: the owning window's next frame gives it
+    // a pane (`_syncOverlay`), and the child-list claim asks for that frame
+    this.root?._overlaid?.add(this);
   }
 
   /** Create the GL child window. Async: the visual comes from the server. */
@@ -203,7 +219,9 @@ export class GlAreaNode extends Node {
     recordGlxFailure(this.app, err);
     this.gl = null;
     if (this.window) {
-      this._leaveSurfaces();
+      // the children's panes stay, over whatever the fallback draws, and
+      // stay hittable; with none, nothing of this node covers the rect
+      if (!this._overlay) this._leaveSurfaces();
       this.window.destroy?.();
       this.window = null;
       this.rect = null;
@@ -252,7 +270,7 @@ export class GlAreaNode extends Node {
     // its siblings, and Core Animation a layer added later over one at the
     // same zPosition. The window's hit test reads the list in that order
     // (`EventManager._surfaceAt`).
-    this.root?._surfaces?.push(this);
+    this._joinSurfaces();
     this.gl = wnd.getContext('opengl', config);
     // a buffer freed by the display is a frame that can be drawn again
     if (typeof this.gl?.onFrameAvailable !== 'undefined') {
@@ -267,6 +285,9 @@ export class GlAreaNode extends Node {
     });
     wnd.on?.('expose', () => this.requestFrame());
     wnd.map?.();
+    // made on top of its siblings — over the panes of children that were
+    // laid out and painted before the visual query answered
+    this._overlay?.restack();
     this.requestFrame();
   }
 
@@ -416,27 +437,30 @@ export class GlAreaNode extends Node {
   }
 
   /**
-   * This node, if a point in the owning window's space is over the surface.
+   * What a point in the owning window's space lands on, if it is over this
+   * surface: the child under it where there is one — the children are drawn
+   * above the surface (src/gloverlay.js) — and otherwise this node.
    *
-   * A point that is, is over it whatever the tree's own order says: X stacks
-   * the child window above the parent's drawing, and the Cocoa backend puts
-   * the layer at a zPosition over both presenters. So the window asks its
-   * surfaces before it hit-tests its tree (`EventManager._hit`), and a point
-   * inside lands here rather than on the box behind — which is all a tree
-   * walk can find, a window-owning node not being in its parent's paint
-   * order. It is the same answer X gives: the event it propagates to the
-   * owning window names this window as the child the pointer is in.
+   * A point that is over the surface is over it whatever the tree's own
+   * order says: X stacks the child window above the parent's drawing, and
+   * the Cocoa backend puts the layer at a zPosition over both presenters. So
+   * the window asks its surfaces before it hit-tests its tree
+   * (`EventManager._hit`), and a point inside lands here rather than on the
+   * box behind — which is all a tree walk can find, a window-owning node not
+   * being in its parent's paint order. It is the same answer X gives: the
+   * event it propagates to the owning window names this window, or a pane
+   * over it, as the child the pointer is in.
    *
-   * The rect is the one last sent to the surface rather than `abs`, since
-   * the surface covers whole pixels and the server decides by those. No
-   * surface, no answer: not made yet, given up after `onError`, or hidden
-   * with something around it — and `pointerEvents: 'none'` here or above
-   * lets the pointer through to what the tree has behind, as it does for
-   * any node.
+   * The rect is the surface's own, in whole pixels, since the server decides
+   * by those. With no GL surface — not made yet, or given up after
+   * `onError` — only the children answer, and a point between them is the
+   * tree's. Hidden, or `pointerEvents: 'none'` here or above, lets the
+   * pointer through to what the tree has behind, as it does for any node.
    */
   hitSurface(x, y) {
-    const rect = this.rect;
-    if (!this.window || !rect) return null;
+    const panes = this._overlay?.panes.length ?? 0;
+    if (!this.window && panes === 0) return null;
+    const rect = this.rect ?? this._geometry();
     if (
       x < rect.x ||
       y < rect.y ||
@@ -452,7 +476,22 @@ export class GlAreaNode extends Node {
       }
       if (n.isWindow) break;
     }
-    return this;
+    if (panes !== 0) {
+      // front to back, as the tree's own hit test walks a box's children
+      const order = this.paintOrder();
+      for (let i = order.length - 1; i >= 0; i--) {
+        const hit = order[i].hitTest(x, y);
+        if (hit) return hit;
+      }
+    }
+    return this.window ? this : null;
+  }
+
+  /** Into the owning window's hit test, once: a GL window or a pane covers
+   * the rect now (`EventManager._surfaceAt`). */
+  _joinSurfaces() {
+    const surfaces = this.root?._surfaces;
+    if (surfaces && !surfaces.includes(this)) surfaces.push(this);
   }
 
   /** Out of the owning window's hit test: nothing covers the rect any more,
@@ -461,6 +500,34 @@ export class GlAreaNode extends Node {
     const surfaces = this.root?._surfaces;
     const at = surfaces ? surfaces.indexOf(this) : -1;
     if (at !== -1) surfaces.splice(at, 1);
+  }
+
+  /**
+   * The owning window's frame, after layout (`WindowNode._syncOverlays`):
+   * panes for where the children are now. True when a pane was made,
+   * resized or dropped — a paint the frame then owes.
+   */
+  _syncOverlay() {
+    if (!this._overlay) {
+      if (this.children.length === 0 || !canOverlay(this.app)) {
+        this.root?._overlaid?.delete(this);
+        return false;
+      }
+      this._overlay = new GlOverlay(this);
+    }
+    const changed = this._overlay.sync();
+    if (this._overlay.panes.length) this._joinSurfaces();
+    if (this.children.length === 0 && this._overlay.panes.length === 0) {
+      this._overlay = null;
+      this.root?._overlaid?.delete(this);
+      if (!this.window) this._leaveSurfaces();
+    }
+    return changed;
+  }
+
+  /** …and the paint it owes them, with the frame's damage. */
+  _paintOverlay(damage) {
+    this._overlay?.paint(damage);
   }
 
   applyProps(newProps, oldProps) {
@@ -475,15 +542,27 @@ export class GlAreaNode extends Node {
     super.setHidden(hidden);
     if (hidden) this.window?.unmap?.();
     else this.window?.map?.();
+    this._overlay?.setHidden(hidden);
   }
 
-  // the child window covers this rect: nothing to paint into the parent's
-  // 2d context, and no drawn children are allowed under it
+  // The surface covers this rect: nothing of this node is painted into the
+  // parent's 2d context, and its children are painted above the surface on
+  // panes of their own (src/gloverlay.js) rather than in the window's walk.
   paint() {}
+
+  // …which is also why they are cut to its box: a pane never reaches past
+  // the surface, and the hit test and the damage model have to agree with
+  // the panes about where the children can be
+  clipsChildren() {
+    return true;
+  }
 
   destroySubtree() {
     if (this.destroyed) return;
     this._leaveSurfaces();
+    this.root?._overlaid?.delete(this);
+    this._overlay?.destroy();
+    this._overlay = null;
     super.destroySubtree();
     this._pacer.cancel();
     this.gl?.destroy?.();

--- a/src/gloverlay.js
+++ b/src/gloverlay.js
@@ -1,0 +1,383 @@
+// The children of a `<glarea>`: 2D content, drawn above the GL surface.
+//
+// A surface is stacked over everything 2D in its window — a child X window
+// above the parent's drawing on X11, a layer at zPosition 1e7 over both
+// presenters on the Cocoa backend — so the window's own paint walk can never
+// put a pixel on it, and does not try: a `<glarea>` is in no paint order, and
+// so is nothing under it. Its children are otherwise ordinary. They are laid
+// out in its box like a `<box>`'s; they live in the owning window's tree, so
+// their claims land in its damage list and their input comes through its
+// event manager, the hit test asking them before the surface itself
+// (`GlAreaNode.hitSurface`). What is theirs alone is where they are painted:
+// into *panes* above the surface, from inside the owning window's frame and
+// with that frame's damage (nodes/window/flush.js, `_syncOverlays` and
+// `_paintOverlays`).
+//
+// A pane is the backend's answer to one question — can a window composite a
+// translucent child over a GL surface?
+//
+// - **The Cocoa backend: yes.** Core Animation composites every layer, so
+//   one pane holds everything — a transparent bitmap layer over the whole
+//   surface, above the GL layer — and a translucent background, an
+//   antialiased edge or a shadow blends with the GL frame under it.
+//   `app.createOverlayPane` is how a backend says it composites.
+// - **X11: no.** A child window is opaque without a compositor, and a
+//   compositor would not change that: it redirects top-level windows, not
+//   the children inside one. So a pane is a plain child window just big
+//   enough for what it holds, one per region the children reach, and the
+//   surface shows between them. Inside a pane the ground is the surface's
+//   `clearColor` — the colour its frames start from — so a pixel a child
+//   leaves unpainted there (a rounded corner, a translucent background, text
+//   with no box behind it) shows that colour, never the GL frame.
+//
+//   A window per region rather than one window shaped by the SHAPE
+//   extension, for two reasons: SHAPE is near-universal but not universal —
+//   node-x11's in-process server, where this is tested, has none — and a
+//   window as big as the surface would keep a backing pixmap the size of a
+//   map to show a legend in its corner.
+//
+// A pane selects no input, so the pointer over one reaches the owning window
+// by the same propagation that brings it the pointer over the surface
+// (src/glnodes.js, `_create`), and lands on the child it is over.
+//
+// A leaf module, like src/embedding.js: `appcontext.js` asks `canOverlay`
+// for `useSupports('glOverlay')`, and it imports nothing of ours.
+import { cssColorStraight } from 'ntk';
+
+// ConfigureWindow's stack mode: directly above the sibling it names
+const STACK_ABOVE = 0;
+
+/**
+ * Whether the children of a `<glarea>` can be drawn over its surface on this
+ * connection: a backend that composites a pane itself, or one that can make
+ * the plain child window a pane is on X11. One function for the element and
+ * for `useSupports('glOverlay')`, which have to agree — the rule `canEmbed`
+ * follows for `<foreign>`.
+ */
+export function canOverlay(app) {
+  return (
+    typeof app?.createOverlayPane === 'function' ||
+    typeof app?.createWindow === 'function'
+  );
+}
+
+/** A rect grown out to whole device pixels. */
+function whole(r) {
+  const x = Math.floor(r.x);
+  const y = Math.floor(r.y);
+  return {
+    x,
+    y,
+    width: Math.ceil(r.x + r.width) - x,
+    height: Math.ceil(r.y + r.height) - y,
+  };
+}
+
+function intersect(a, b) {
+  const x = Math.max(a.x, b.x);
+  const y = Math.max(a.y, b.y);
+  const right = Math.min(a.x + a.width, b.x + b.width);
+  const bottom = Math.min(a.y + a.height, b.y + b.height);
+  return right > x && bottom > y
+    ? { x, y, width: right - x, height: bottom - y }
+    : null;
+}
+
+const overlaps = (a, b) =>
+  a.x < b.x + b.width &&
+  b.x < a.x + a.width &&
+  a.y < b.y + b.height &&
+  b.y < a.y + a.height;
+
+function around(a, b) {
+  const x = Math.min(a.x, b.x);
+  const y = Math.min(a.y, b.y);
+  return {
+    x,
+    y,
+    width: Math.max(a.x + a.width, b.x + b.width) - x,
+    height: Math.max(a.y + a.height, b.y + b.height) - y,
+  };
+}
+
+const sameRect = (a, b) =>
+  a.x === b.x && a.y === b.y && a.width === b.width && a.height === b.height;
+
+/** On screen: nothing from here to the window hidden or `display: 'none'`. */
+function shown(node) {
+  for (let n = node; n; n = n.parent) {
+    if (n.destroyed || n.hidden || n.style?.display === 'none') return false;
+    if (n.isWindow) break;
+  }
+  return true;
+}
+
+/**
+ * Where the children put ink, as rects no two of which overlap: each drawn
+ * child's reach in whole pixels, cut to the surface, and any two that
+ * overlap merged into the box around both. A pane is a rectangle, and two
+ * panes over one pixel would each have to hold what the other draws there.
+ *
+ * The reach is `_subtreeBounds()`, the rect the damage model culls against —
+ * so a child's shadow, its outline and a descendant that sticks out of it
+ * are all inside its pane.
+ */
+export function overlayRegions(area, surface) {
+  const rects = [];
+  for (const child of area.paintOrder()) {
+    const reach = intersect(whole(child._subtreeBounds()), surface);
+    if (reach) rects.push(reach);
+  }
+  for (let merged = true; merged;) {
+    merged = false;
+    search: for (let i = 0; i < rects.length; i++) {
+      for (let j = i + 1; j < rects.length; j++) {
+        if (overlaps(rects[i], rects[j])) {
+          rects[i] = around(rects[i], rects[j]);
+          rects.splice(j, 1);
+          merged = true;
+          break search;
+        }
+      }
+    }
+  }
+  return rects;
+}
+
+/**
+ * The colour an opaque pane is filled with before its children paint: the
+ * surface's `clearColor`, what the GL frame under the pane starts from, at
+ * full alpha. The pane is opaque, and a translucent fill would pile up on
+ * the pane's own last frame rather than show anything under it.
+ */
+function groundOf(props) {
+  const value = props.clearColor ?? 'black';
+  const [r, g, b] = Array.isArray(value)
+    ? value
+    : (cssColorStraight(value) ?? [0, 0, 0, 1]);
+  const byte = (c) => Math.round(Math.max(0, Math.min(1, c)) * 255);
+  return `rgb(${byte(r)}, ${byte(g)}, ${byte(b)})`;
+}
+
+/**
+ * One pane: the window — or on the Cocoa backend the layer, which speaks the
+ * same few verbs — and what the overlay knows about it: where it is, whether
+ * all of it is owed a paint, and its 2d context, made once, since ntk builds
+ * a fresh one with subscriptions of its own on every `getContext`.
+ */
+class Pane {
+  constructor(wnd, rect, transparent) {
+    this.wnd = wnd;
+    this.rect = rect;
+    this.transparent = transparent;
+    this.full = true;
+    this.ctx = null;
+  }
+
+  context() {
+    if (!this.ctx && typeof this.wnd.getContext === 'function') {
+      this.ctx = this.wnd.getContext('2d');
+    }
+    return this.ctx;
+  }
+
+  /** Somewhere else. A new size is a new backing — a pixmap on X11, a
+   * bitmap on Cocoa — and has to be painted whole; a move keeps what the
+   * pane holds, which moved with the children it shows. */
+  place(rect) {
+    if (rect.width !== this.rect.width || rect.height !== this.rect.height) {
+      this.full = true;
+    }
+    this.rect = rect;
+    if (typeof this.wnd.setState === 'function') this.wnd.setState(rect);
+    else {
+      this.wnd.move?.(rect.x, rect.y);
+      this.wnd.resize?.(rect.width, rect.height);
+    }
+  }
+
+  show(on) {
+    if (on) this.wnd.map?.();
+    else this.wnd.unmap?.();
+  }
+
+  destroy() {
+    this.wnd.destroy?.();
+    this.ctx = null;
+  }
+}
+
+/** A `<glarea>`'s panes, from the owning window's frame. */
+export class GlOverlay {
+  constructor(area) {
+    this.area = area;
+    this.app = area.app;
+    // one pane over the whole surface, where the backend composites it
+    this.composited = typeof this.app?.createOverlayPane === 'function';
+    this.panes = [];
+  }
+
+  /**
+   * After layout: panes for where the children are now. True when a pane was
+   * made, resized or dropped — a paint the frame then owes.
+   *
+   * Nothing is made for a surface that is hidden, or has no area, or has no
+   * child on screen: a pane with nothing on it would only hide the surface.
+   * The panes of one that goes are dropped rather than kept unmapped, and
+   * the frame that brings it back makes new ones and paints them whole.
+   */
+  sync() {
+    const area = this.area;
+    const abs = area.abs;
+    let rects = [];
+    if (shown(area) && abs.width > 0 && abs.height > 0) {
+      // the surface's own rect, rounded the way its window's is
+      const surface = area._geometry();
+      if (!this.composited) rects = overlayRegions(area, surface);
+      else if (area.paintOrder().length) rects = [surface];
+    }
+    let changed = false;
+    while (this.panes.length > rects.length) {
+      this.panes.pop().destroy();
+      changed = true;
+    }
+    let made = false;
+    for (let i = 0; i < rects.length; i++) {
+      const pane = this.panes[i];
+      if (!pane) {
+        this.panes.push(this._makePane(rects[i]));
+        made = changed = true;
+      } else if (!sameRect(pane.rect, rects[i])) {
+        pane.place(rects[i]);
+        changed = true;
+      }
+    }
+    if (made) this.restack();
+    return changed;
+  }
+
+  _makePane(rect) {
+    const owner = this.area.root.window;
+    const attributes = { parent: owner, ...rect };
+    const pane = this.composited
+      ? new Pane(this.app.createOverlayPane(attributes), rect, true)
+      : // A plain child window on the owning window's visual, selecting
+        // nothing but what ntk selects for itself — the structure events and
+        // the exposures its backing store answers. The pointer is the tree's.
+        new Pane(this.app.createWindow(attributes), rect, false);
+    // ntk asks for a redraw when the backing no longer holds the picture — a
+    // resize it could not carry over — and a pane has nothing to redraw from
+    // but the children, on the next frame of the window they live in
+    pane.wnd.on?.('draw', () => this._lost(pane));
+    pane.show(true);
+    return pane;
+  }
+
+  /** A pane whose pixels are gone: all of it is owed, on the owning window's
+   * next frame, claimed as its rect so the rest of the window stays put. */
+  _lost(pane) {
+    pane.full = true;
+    const root = this.area.root;
+    if (root && !root.destroyed)
+      root.invalidate(false, { ...pane.rect }, 'expose');
+  }
+
+  /**
+   * Put the panes directly over the surface, bottom to top. Only X11 needs
+   * it: a child window is made on top of its siblings, which is right for a
+   * pane made after the surface and wrong for one made before it — the
+   * surface's window is made once its visual is known, which can be after
+   * the first frame has laid out and painted its children. So the surface
+   * restacks its panes when its own window is made, too (`_create`). On the
+   * Cocoa backend the layer's zPosition is the whole of it.
+   */
+  restack() {
+    if (this.composited) return;
+    const X = this.app?.X;
+    if (typeof X?.ConfigureWindow !== 'function') return;
+    let below = this.area.window?.id ?? null;
+    for (const pane of this.panes) {
+      const id = pane.wnd.id;
+      if (id == null) continue;
+      if (below == null) X.ConfigureWindow(id, { stackMode: STACK_ABOVE });
+      else X.ConfigureWindow(id, { sibling: below, stackMode: STACK_ABOVE });
+      below = id;
+    }
+  }
+
+  /**
+   * Paint what the frame owes: every pane whole after it was made, resized
+   * or lost its pixels, and otherwise the frame's damage cut to each pane —
+   * `null` damage meaning the whole window, as it does for the paint walk.
+   *
+   * Each pass is the window's own paint walk over the children, translated
+   * so the pane's corner is the bitmap's, clipped to the pass, with
+   * `paintDamage()` naming it — the same culling, the same paint cache, the
+   * same everything as a pass over the window, and in its coordinates.
+   */
+  paint(damage) {
+    for (const pane of this.panes) {
+      let passes;
+      if (pane.full || !damage) {
+        passes = [pane.rect];
+      } else {
+        passes = [];
+        for (const rect of damage) {
+          const hit = intersect(rect, pane.rect);
+          if (hit) passes.push(hit);
+        }
+        if (passes.length === 0) continue;
+      }
+      pane.full = false;
+      this._paintPane(pane, passes);
+    }
+  }
+
+  _paintPane(pane, passes) {
+    const area = this.area;
+    const root = area.root;
+    const ctx = pane.context();
+    if (!ctx || !root) return;
+    // an opaque pane is filled with what the surface starts its frames from;
+    // a composited one is cleared, and shows the frame itself
+    const ground = pane.transparent ? null : groundOf(area.props);
+    ctx.save();
+    try {
+      ctx.translate(-pane.rect.x, -pane.rect.y);
+      for (const pass of passes) {
+        ctx.save();
+        try {
+          ctx.beginPath();
+          ctx.rect(pass.x, pass.y, pass.width, pass.height);
+          ctx.clip();
+          if (ground) {
+            ctx.fillStyle = ground;
+            ctx.fillRect(pass.x, pass.y, pass.width, pass.height);
+          } else {
+            ctx.clearRect(pass.x, pass.y, pass.width, pass.height);
+          }
+          root._paintDamage = pass;
+          area._paintChildren(ctx);
+        } finally {
+          root._paintDamage = null;
+          ctx.restore();
+        }
+      }
+    } finally {
+      ctx.restore();
+    }
+    // A layer's contents are a copy the bitmap is pushed to; an X window's
+    // backing store is blitted by ntk on its own, from the paint above
+    pane.wnd.present?.();
+  }
+
+  /** Unmapped now; `sync` drops them on the frame the hide lays out. */
+  setHidden(hidden) {
+    for (const pane of this.panes) pane.show(!hidden);
+  }
+
+  destroy() {
+    for (const pane of this.panes) pane.destroy();
+    this.panes = [];
+  }
+}

--- a/src/host.d.ts
+++ b/src/host.d.ts
@@ -21,7 +21,6 @@ import type { NtkApp } from './types/nodes.js';
 export interface HostContext {
   isInsideText: boolean;
   isInsideSvg: boolean;
-  isInside3d: boolean;
 }
 
 export interface ElementDefinition {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -168,9 +168,16 @@ export function useClipboard(): Clipboard;
  * into its own — X11, never Cocoa or the headless mock. Ask it before
  * rendering a `<foreign>`, which refuses with one `onError` where it is
  * false. Also a property of the backend, and it never changes either.
+ *
+ * `'glOverlay'` is whether the children of a `<glarea>` are drawn above its
+ * GL surface — laid out in its box, painted on panes stacked over it, hit
+ * before it. Both backends draw them; translucency is the difference,
+ * composited by Core Animation on Cocoa and opaque on X11, where what a
+ * child leaves unpainted shows the surface's `clearColor` (docs/elements.md).
+ * Ask it before handing a surface its HUD. A property of the backend.
  */
 export type SupportsFeature =
-  'transparency' | 'shaders' | 'nativeControls' | 'embedding';
+  'transparency' | 'shaders' | 'nativeControls' | 'embedding' | 'glOverlay';
 
 /**
  * Can this **display** do something? `'transparency'` is true when the

--- a/src/nodes/window/flush.js
+++ b/src/nodes/window/flush.js
@@ -85,6 +85,29 @@ export class WindowFlush {
   }
 
   /**
+   * Panes for the children of every `<glarea>` here, where this frame's
+   * layout put them (src/gloverlay.js). True when one was made, resized or
+   * dropped, which the frame then owes a paint for.
+   */
+  _syncOverlays() {
+    let changed = false;
+    for (const area of this._overlaid) {
+      if (area.destroyed || area.root !== this) {
+        this._overlaid.delete(area);
+        continue;
+      }
+      if (area._syncOverlay()) changed = true;
+    }
+    return changed;
+  }
+
+  /** …and their paint, with the frame's own damage: a claim inside a
+   * `<glarea>`'s children is in that list like any other. */
+  _paintOverlays(damage) {
+    for (const area of this._overlaid) area._paintOverlay(damage);
+  }
+
+  /**
    * A frame: layout if owed, then the paint passes — or the presenter's
    * frame — then the backend's word. Runs on the window's clock through
    * `_scheduleFrame`, and early, synchronously, for a discrete input
@@ -254,6 +277,12 @@ export class WindowFlush {
     // …and the next commit's claims name the arrangement this frame leaves
     // behind again, from before whatever scroll comes with them
     this._laidOut = false;
+    // The children of a `<glarea>` get panes where they are now: after
+    // layout and the scroll's shift, before the damage is taken, so a pane
+    // made or resized in this frame is painted in it, whole
+    if (this._overlaid.size !== 0 && this._syncOverlays()) {
+      this.needsPaint = true;
+    }
     if (!this.needsPaint) return false;
     this.needsPaint = false;
     const damage = this._takeDamage(width, height);
@@ -276,6 +305,8 @@ export class WindowFlush {
     // list was still taken (its bookkeeping is what keeps the two paths one
     // code) and is simply not consumed; the presenter diffs at the layer.
     if (typeof this.window.presentFrame === 'function') {
+      // the panes are no presenter's: they paint from the damage either way
+      if (this._overlaid.size !== 0) this._paintOverlays(damage);
       this.window.presentFrame(this, damage);
       this.app._reactX11Startup?.painted();
       return true;
@@ -297,6 +328,10 @@ export class WindowFlush {
     for (const rect of damage ?? [null]) {
       this._paintRegion(ctx, rect, width, height);
     }
+    // …and the panes over the surfaces, with the same damage: a claim from
+    // a `<glarea>`'s children is theirs to repaint — the window's pass under
+    // the surface is one nobody sees. Inside the cache's frame, like a pass.
+    if (this._overlaid.size !== 0) this._paintOverlays(damage);
     // after every region: an entry drawn in one damage rect must not be
     // evicted before the next rect of the same frame asks for it
     this._paintCache?.endFrame();

--- a/src/nodes/window/window.js
+++ b/src/nodes/window/window.js
@@ -196,6 +196,10 @@ export class WindowNode extends Scrollable(Node) {
     // tree (`EventManager._surfaceAt`). A surface joins when its window is
     // made and leaves when it goes (src/glnodes.js).
     this._surfaces = [];
+    // …and the ones with children, whose panes each frame syncs after layout
+    // and paints with its damage (nodes/window/flush.js, src/gloverlay.js).
+    // Empty is one `size` read a frame.
+    this._overlaid = new Set();
     this.events = new EventManager(this);
     // ids of the child windows in the order the *server* stacks them,
     // bottom to top — see _restackWindowChildren

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -916,10 +916,14 @@ export interface SvgProps extends DrawnProps<DrawnNode> {
 export type FrameLoop = 'demand' | 'always';
 
 /**
- * `<glarea>`: a GL surface in the layout. The pointer over it is the tree's,
- * as over any node — the handlers it inherits (`onMouseDown`, `onClick`,
- * `onWheel`, …) fire at the `<glarea>` and bubble, on both backends — and
- * `GlAreaNode.forwardsPointer` says so at run time (docs/elements.md).
+ * `<glarea>`: a GL surface in the layout. Its **children** are 2D content
+ * drawn above the surface — laid out in its box like a `<box>`'s and cut to
+ * it, painted over the GL frame, hit before it — composited on the Cocoa
+ * backend and opaque on X11 (docs/elements.md); `useSupports('glOverlay')`
+ * asks whether they will be. The pointer over it is the tree's, as over any
+ * node: the handlers it inherits (`onMouseDown`, `onClick`, `onWheel`, …)
+ * fire at the child under the pointer or the `<glarea>` and bubble, on both
+ * backends, and `GlAreaNode.forwardsPointer` says so at run time.
  */
 export interface GlAreaProps extends DrawnProps<DrawnNode> {
   /** CSS colour, or `[r, g, b, a]` floats. Default black. */

--- a/test/cocoa-glarea.test.js
+++ b/test/cocoa-glarea.test.js
@@ -54,9 +54,15 @@ const findGLArea = (node) =>
 /**
  * A `<glarea>` inset 10px in a 200x120 `<window>` at scale 2, mounted, its
  * surface created and a frame run. `area` and `box` are extra props for the
- * surface and the box around it.
+ * surface and the box around it, `children` the surface's own, `sibling` one
+ * more child of the box, after the surface.
  */
-async function mountGLArea({ area = {}, box = {} } = {}) {
+async function mountGLArea({
+  area = {},
+  box = {},
+  children = null,
+  sibling = null,
+} = {}) {
   const { native, app } = fakeCocoaApp();
   // the runtime chooseGLConfig resolves, settled before anything asks: no
   // x11-dri and no CGL context, so this runs on any OS
@@ -72,7 +78,8 @@ async function mountGLArea({ area = {}, box = {} } = {}) {
       h(
         'box',
         { style: { flexGrow: 1, padding: 10 }, ...box },
-        h('glarea', { style: { flexGrow: 1 }, ...area }),
+        h('glarea', { key: 'gl', style: { flexGrow: 1 }, ...area }, children),
+        sibling,
       ),
     ),
   );
@@ -86,8 +93,22 @@ async function mountGLArea({ area = {}, box = {} } = {}) {
     app._presentAll();
   };
   frame();
-  return { native, wnd, node, frame };
+  return { native, app, root, wnd, node, frame };
 }
+
+/** A box at a corner of the surface, 20x10 points, half transparent. */
+const legend = (props = {}) =>
+  h('box', {
+    style: {
+      position: 'absolute',
+      left: 5,
+      top: 5,
+      width: 20,
+      height: 10,
+      backgroundColor: 'rgba(255, 0, 0, 0.5)',
+    },
+    ...props,
+  });
 
 /**
  * Every `setLayerProps` on `layer`, in order, each with whether a
@@ -165,4 +186,136 @@ test('the pointer over the surface is dispatched at the <glarea>, and bubbles', 
     ],
   );
   void native;
+});
+
+test('the children are drawn on a transparent layer above the surface', async () => {
+  // One pane over the whole surface, because Core Animation composites it:
+  // a translucent child blends with the GL frame, which X11 cannot do.
+  const { native, wnd, node, frame } = await mountGLArea({
+    children: legend(),
+  });
+  frame();
+  const gl = node.window.layer;
+  const overlay = wnd._layer.sublayers.find((l) => l.props.zPosition > 1e7);
+  assert.ok(overlay, 'a layer over the GL layer');
+  assert.ok(overlay !== gl, 'not the GL layer itself');
+  assert.equal(gl.props.zPosition, 1e7);
+  // exactly over the surface, in points, and on show once painted
+  assert.deepEqual(overlay.props.frame, gl.props.frame);
+  assert.equal(overlay.props.hidden, false);
+  assert.ok(overlay.contents, 'the painted bitmap was pushed to it');
+  // the bitmap is the surface's size in device pixels — at scale 2
+  const [pane] = node._overlay.panes;
+  assert.deepEqual(
+    [pane.wnd._surfaceSize.width, pane.wnd._surfaceSize.height],
+    [360, 200],
+  );
+  // transparent: each pass is cleared, never filled with a ground colour
+  const surface = pane.wnd._surface;
+  const onPane = native.calls.filter((c) => c.args[0] === surface);
+  assert.ok(
+    onPane.some((c) => c.name === 'ctxClearRect'),
+    'cleared',
+  );
+  // every set on the layer went out with implicit animations off
+  const loose = layerSets(native, overlay).filter((s) => !s.still);
+  assert.deepEqual(loose, []);
+});
+
+test('the pointer over a child of the surface is the child’s', async () => {
+  const seen = [];
+  const { app, node } = await mountGLArea({
+    area: { onMouseDown: (ev) => seen.push(['area', ev.target]) },
+    children: legend({ onMouseDown: (ev) => seen.push(['legend', ev.target]) }),
+  });
+  const [child] = node.children;
+  pointerOver(app, child, { press: true });
+  assert.deepEqual(
+    seen.map(([who, target]) => [who, target === child]),
+    [
+      ['legend', true],
+      ['area', true],
+    ],
+  );
+});
+
+test('a child of the surface is never promoted onto a layer of its own', async () => {
+  // A promoted node's layer sits on the root layer at its paint order's
+  // zPosition — under the GL layer at 1e7 — so a child of the surface lifted
+  // there like any animated box would vanish behind the surface it is drawn
+  // over. The control, a sibling of the surface with the same transition, is
+  // promoted: the surface presenter promotes by default.
+  const fade = (backgroundColor, left) => ({
+    position: 'absolute',
+    left,
+    top: 5,
+    width: 20,
+    height: 10,
+    backgroundColor,
+    transition: { backgroundColor: 120 },
+  });
+  const tree = (color) =>
+    h(
+      'window',
+      { width: 200, height: 120 },
+      h(
+        'box',
+        { style: { flexGrow: 1, padding: 10 } },
+        h(
+          'glarea',
+          { key: 'gl', style: { flexGrow: 1 } },
+          h('box', { style: fade(color, 5) }),
+        ),
+        h('box', { key: 'control', style: fade(color, 150) }),
+      ),
+    );
+  const { root, wnd, node, frame } = await mountGLArea({
+    children: h('box', { style: fade('#ff0000', 5) }),
+    sibling: h('box', { key: 'control', style: fade('#ff0000', 150) }),
+  });
+  const [child] = node.children;
+  const control = node.parent.children[1];
+  root.render(tree('#0000ff'));
+  await tick();
+  assert.ok(wnd._promotion, 'this window promotes');
+  // Decided at the swap, not by the frame: the control's animation is taken
+  // off the frame clock and offered to a layer, the child's never is. A
+  // frame declines a node the paint walk never reaches anyway, so
+  // `_promoted` alone could not tell this rule from its absence.
+  assert.ok(child._anim?.get('backgroundColor'), 'the child’s is running');
+  assert.ok(
+    control._anim?.get('backgroundColor')?.offloaded,
+    'the control’s is offered to a layer',
+  );
+  assert.ok(
+    !child._anim.get('backgroundColor').offloaded,
+    'the child’s stays on the frame clock',
+  );
+  frame();
+  assert.equal(control._promoted, true, 'the control was promoted');
+  assert.equal(child._promoted, false, 'the child of the surface was not');
+});
+
+test('the layer goes with the last child', async () => {
+  const { root, wnd, node, frame } = await mountGLArea({
+    children: legend(),
+  });
+  frame();
+  const overlay = wnd._layer.sublayers.find((l) => l.props.zPosition > 1e7);
+  assert.ok(overlay);
+  root.render(
+    h(
+      'window',
+      { width: 200, height: 120 },
+      h(
+        'box',
+        { style: { flexGrow: 1, padding: 10 } },
+        h('glarea', { style: { flexGrow: 1 } }),
+      ),
+    ),
+  );
+  await tick();
+  frame();
+  assert.equal(overlay.parent, null, 'off the root layer');
+  assert.ok(node._overlay === null, 'no overlay left');
 });

--- a/test/glarea-overlay.test.js
+++ b/test/glarea-overlay.test.js
@@ -1,0 +1,554 @@
+// A <glarea>'s children: 2D content drawn above the GL surface
+// (src/gloverlay.js), on X11.
+//
+// Hermetic, like test/glarea.test.js: node-x11's in-process server with its
+// GLX emulator registered, so the surface is a real GL child window and the
+// panes are real child windows beside it. The in-process server keeps every
+// window's pixels apart, so a pane's backing store is exactly what it shows,
+// and the stacking the server reports is exactly what a real one would.
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { test } from 'node:test';
+
+import React from 'react';
+import x11 from 'x11';
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient, StaticFontSource } from 'ntk';
+
+import { createRoot, useSupports } from '../src/index.js';
+
+const require = createRequire(import.meta.url);
+const { createGlxExtension, RecordingBackend } = require('x11/browser/glx');
+
+const h = React.createElement;
+
+const POINTER_INPUT =
+  x11.eventMask.ButtonPress |
+  x11.eventMask.ButtonRelease |
+  x11.eventMask.PointerMotion;
+
+async function createGlApp({ indirectContexts = true } = {}) {
+  const server = xserver.createServer({ width: 640, height: 480 });
+  server.registerExtension(
+    'GLX',
+    createGlxExtension({
+      backend: new RecordingBackend(),
+      indirectContexts,
+      getDrawableSurface: () => null,
+    }),
+  );
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  const app = await createClient({
+    stream: clientEnd,
+    fontSource: new StaticFontSource(),
+    onXError: () => {},
+  });
+  return { app, server };
+}
+
+async function waitFor(check, what, timeout = 3000) {
+  const deadline = Date.now() + timeout;
+  for (;;) {
+    if (check()) return;
+    if (Date.now() > deadline) assert.fail(`timed out waiting for ${what}`);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
+
+/** `waitFor`, for a check that has to ask the server. */
+async function eventually(check, what, timeout = 3000) {
+  const deadline = Date.now() + timeout;
+  for (;;) {
+    if (await check()) return;
+    if (Date.now() > deadline) assert.fail(`timed out waiting for ${what}`);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
+
+const settle = async (app, roundTrips = 3) => {
+  for (let i = 0; i < roundTrips; i++) {
+    await new Promise((resolve) => app.X.GetInputFocus(() => resolve()));
+  }
+};
+
+/** The children of an X window, bottom to top — the server's stacking. */
+const stacking = (app, wid) =>
+  new Promise((resolve, reject) =>
+    app.X.QueryTree(wid, (err, tree) =>
+      err ? reject(err) : resolve(tree.children),
+    ),
+  );
+
+/** `[r, g, b]` at a point of a window's backing store, window-local. */
+function rgbOf(wnd, x, y) {
+  const ctx = wnd.getContext('2d');
+  return new Promise((resolve, reject) =>
+    ctx.getImageData(x, y, 1, 1, (err, image) =>
+      err ? reject(err) : resolve([...image.data.slice(0, 3)]),
+    ),
+  );
+}
+
+const near = (got, want, what, tolerance = 2) =>
+  assert.ok(
+    got.every((c, i) => Math.abs(c - want[i]) <= tolerance),
+    `${what}: got rgb(${got}), want rgb(${want})`,
+  );
+
+/**
+ * Nodes are compared by identity and named in the message, never handed to
+ * `assert.equal`: a failed comparison `util.inspect`s both sides, a node
+ * reaches the whole tree, the app and its connection, and the report then
+ * takes minutes — a regression hangs the suite instead of failing it. Found
+ * by planting one.
+ */
+const nameOf = (v) =>
+  v == null
+    ? String(v)
+    : v.kind
+      ? `<${v.kind}>`
+      : v.id != null
+        ? `window ${v.id}`
+        : typeof v;
+function same(actual, expected, what) {
+  assert.ok(
+    actual === expected,
+    `${what}: got ${nameOf(actual)}, want ${nameOf(expected)}`,
+  );
+}
+
+const whole = (r) => {
+  const x = Math.floor(r.x);
+  const y = Math.floor(r.y);
+  return {
+    x,
+    y,
+    width: Math.ceil(r.x + r.width) - x,
+    height: Math.ceil(r.y + r.height) - y,
+  };
+};
+
+/**
+ * `build()` mounted in a 320x240 window and settled: the surface made (or
+ * given up), its children laid out and their panes painted.
+ */
+async function mount(build, { indirectContexts = true, panes = null } = {}) {
+  const { app, server } = await createGlApp({ indirectContexts });
+  const root = await createRoot({ app });
+  const close = async () => {
+    await root.unmount();
+    await app.close();
+  };
+  const render = (element) =>
+    new Promise((resolve) => root.render(element, resolve));
+  const instance = await render(build());
+  const windowNode = instance._reactX11Node;
+  const find = (n) =>
+    n.kind === 'glarea' ? n : n.children.map(find).find(Boolean);
+  const area = () => find(windowNode);
+  try {
+    await waitFor(
+      () =>
+        (area()?.window || area()?.error) &&
+        (panes === null || (area()._overlay?.panes.length ?? 0) === panes),
+      'the surface and its panes',
+    );
+    await settle(app);
+  } catch (err) {
+    // A mount that never settled still holds a connection, and a process
+    // with one open never exits: a regression here would hang the suite
+    // rather than fail it.
+    await close();
+    throw err;
+  }
+  return {
+    app,
+    server,
+    root,
+    windowNode,
+    area,
+    render: async (element) => {
+      await render(element);
+      await settle(app);
+    },
+    at(x, y) {
+      const wnd = windowNode.window;
+      const origin = wnd._screenOrigin ?? { x: wnd.x ?? 0, y: wnd.y ?? 0 };
+      server.injectPointerMove(origin.x + x, origin.y + y);
+    },
+    async close() {
+      await root.unmount();
+      await app.close();
+    },
+  };
+}
+
+const RED = [255, 0, 0];
+const BLUE = [0, 0, 255];
+const GREEN = [0, 128, 0];
+
+/** A surface with a legend in one corner and a panel in the other. */
+function legendAndPanel({ legend = '#ff0000', panel = true, ...extra } = {}) {
+  return h(
+    'window',
+    { width: 320, height: 240 },
+    h(
+      'glarea',
+      {
+        style: { flexGrow: 1 },
+        clearColor: '#102030',
+        onDraw: () => {},
+        ...extra,
+      },
+      h('box', {
+        key: 'legend',
+        style: {
+          position: 'absolute',
+          left: 10,
+          top: 10,
+          width: 60,
+          height: 30,
+          backgroundColor: legend,
+        },
+      }),
+      panel &&
+        h('box', {
+          key: 'panel',
+          style: {
+            position: 'absolute',
+            right: 10,
+            bottom: 10,
+            width: 80,
+            height: 40,
+            backgroundColor: '#0000ff',
+          },
+        }),
+    ),
+  );
+}
+
+test('the children of a <glarea> are drawn on panes stacked above the surface', async () => {
+  const s = await mount(() => legendAndPanel(), { panes: 2 });
+  try {
+    const area = s.area();
+    const [legend, panel] = area.children;
+    // laid out in the surface's box, like a <box>'s
+    assert.deepEqual(legend.abs, { x: 10, y: 10, width: 60, height: 30 });
+    assert.deepEqual(panel.abs, { x: 230, y: 190, width: 80, height: 40 });
+    // one pane per region the children reach, exactly where they are
+    const panes = area._overlay.panes;
+    assert.deepEqual(
+      panes.map((p) => p.rect),
+      [whole(legend.abs), whole(panel.abs)],
+    );
+    // above the surface: the server stacks the panes over the GL window,
+    // which was made after them — its visual query answers after the first
+    // frame — and restacked them over itself
+    const ids = await stacking(s.app, s.windowNode.window.id);
+    const gl = ids.indexOf(area.window.id);
+    assert.ok(gl !== -1, 'the GL window is a child of the owning window');
+    for (const pane of panes) {
+      assert.ok(ids.indexOf(pane.wnd.id) > gl, 'a pane is above the surface');
+    }
+    // painted: each pane holds its child
+    near(await rgbOf(panes[0].wnd, 30, 15), RED, 'the legend');
+    near(await rgbOf(panes[1].wnd, 40, 20), BLUE, 'the panel');
+    // …and the window's own backing does not: the children are the panes'
+    const under = await rgbOf(s.windowNode.window, 40, 25);
+    assert.notDeepEqual(under, RED, 'not painted into the window as well');
+    // no pane takes the pointer: it reaches the tree by propagation
+    for (const pane of panes) {
+      assert.equal(pane.wnd.eventMask & POINTER_INPUT, 0);
+    }
+  } finally {
+    await s.close();
+  }
+});
+
+test('a change inside the overlay repaints its own pane, and no other', async () => {
+  const s = await mount(() => legendAndPanel(), { panes: 2 });
+  try {
+    const [legendPane, panelPane] = s.area()._overlay.panes;
+    // the pane whose child did not change must not be drawn into at all
+    const panelCtx = panelPane.context();
+    let panelFills = 0;
+    const fillRect = panelCtx.fillRect;
+    panelCtx.fillRect = function (...args) {
+      panelFills += 1;
+      return fillRect.apply(this, args);
+    };
+    await s.render(legendAndPanel({ legend: '#008000' }));
+    const green = async () =>
+      (await rgbOf(legendPane.wnd, 30, 15)).every(
+        (c, i) => Math.abs(c - GREEN[i]) <= 2,
+      );
+    await eventually(green, 'the legend, recoloured');
+    near(await rgbOf(panelPane.wnd, 40, 20), BLUE, 'the panel, untouched');
+    assert.equal(panelFills, 0, 'the claim reached only the legend’s pane');
+  } finally {
+    await s.close();
+  }
+});
+
+test('panes follow the layout, and go with the children they held', async () => {
+  // the same shape of tree throughout, so React keeps every node and only
+  // the layout and the child list move under the overlay
+  const tree = (paddingTop, options) =>
+    h(
+      'window',
+      { width: 320, height: 240 },
+      h(
+        'box',
+        { style: { flexGrow: 1, paddingTop } },
+        legendAndPanel(options).props.children,
+      ),
+    );
+  const s = await mount(() => tree(0), { panes: 2 });
+  try {
+    const area = s.area();
+    const before = await stacking(s.app, s.windowNode.window.id);
+    // the surface moves: its children, and their panes, with it
+    await s.render(tree(50));
+    await waitFor(
+      () => area._overlay?.panes[0]?.rect.y === 60,
+      'the legend’s pane moved down',
+    );
+    assert.deepEqual(
+      area._overlay.panes.map((p) => p.rect),
+      area.children.map((c) => whole(c.abs)),
+    );
+    // a pane that only moved keeps what it holds: nothing to repaint
+    near(await rgbOf(area._overlay.panes[0].wnd, 30, 15), RED, 'moved');
+    // a child that goes takes its pane with it — the window too
+    await s.render(tree(50, { panel: false }));
+    await waitFor(() => area._overlay?.panes.length === 1, 'one pane');
+    const after = await stacking(s.app, s.windowNode.window.id);
+    assert.equal(after.length, before.length - 1, 'the pane window is gone');
+    // …and the last one takes the overlay: nothing left over the surface
+    await s.render(
+      h(
+        'window',
+        { width: 320, height: 240 },
+        h(
+          'box',
+          { style: { flexGrow: 1, paddingTop: 50 } },
+          h('glarea', { style: { flexGrow: 1 }, onDraw: () => {} }),
+        ),
+      ),
+    );
+    await waitFor(() => !area._overlay, 'no overlay');
+    const bare = await stacking(s.app, s.windowNode.window.id);
+    assert.deepEqual(bare, [area.window.id], 'only the GL window left');
+    assert.equal(s.windowNode._overlaid.size, 0);
+  } finally {
+    await s.close();
+  }
+});
+
+test('children that overlap share a pane, painted in their order', async () => {
+  const box = (key, left, top, backgroundColor) =>
+    h('box', {
+      key,
+      style: {
+        position: 'absolute',
+        left,
+        top,
+        width: 60,
+        height: 40,
+        backgroundColor,
+      },
+    });
+  const s = await mount(
+    () =>
+      h(
+        'window',
+        { width: 320, height: 240 },
+        h(
+          'glarea',
+          { style: { flexGrow: 1 }, onDraw: () => {} },
+          box('under', 20, 20, '#ff0000'),
+          box('over', 50, 40, '#0000ff'),
+        ),
+      ),
+    { panes: 1 },
+  );
+  try {
+    const [pane] = s.area()._overlay.panes;
+    assert.deepEqual(pane.rect, { x: 20, y: 20, width: 90, height: 60 });
+    near(await rgbOf(pane.wnd, 5, 5), RED, 'the one underneath, alone');
+    near(await rgbOf(pane.wnd, 45, 30), BLUE, 'the overlap: the later one');
+  } finally {
+    await s.close();
+  }
+});
+
+test('on X11 a pane is opaque: what a child leaves unpainted is the surface’s clearColor', async () => {
+  // A translucent fill blends with the pane's ground, which is what the GL
+  // frame under it starts from — not with the frame itself. That is the
+  // documented X11 limit (docs/elements.md); Cocoa composites for real.
+  const s = await mount(
+    () =>
+      h(
+        'window',
+        { width: 320, height: 240 },
+        h(
+          'glarea',
+          { style: { flexGrow: 1 }, clearColor: '#102030', onDraw: () => {} },
+          h('box', {
+            style: {
+              position: 'absolute',
+              left: 10,
+              top: 10,
+              width: 40,
+              height: 40,
+              backgroundColor: 'rgba(255, 0, 0, 0.5)',
+            },
+          }),
+        ),
+      ),
+    { panes: 1 },
+  );
+  try {
+    const [pane] = s.area()._overlay.panes;
+    // 50% red over rgb(16, 32, 48)
+    near(
+      await rgbOf(pane.wnd, 20, 20),
+      [136, 16, 24],
+      'blended with the ground',
+    );
+  } finally {
+    await s.close();
+  }
+});
+
+test('the pointer over a child is the child’s; between the children, the surface’s', async () => {
+  const seen = [];
+  const log = (who) => (ev) => seen.push({ who, target: ev.target });
+  const s = await mount(
+    () =>
+      h(
+        'window',
+        { width: 320, height: 240, onMouseOut: log('window') },
+        h(
+          'glarea',
+          {
+            style: { flexGrow: 1 },
+            onDraw: () => {},
+            onMouseDown: log('area'),
+          },
+          h('box', {
+            style: {
+              position: 'absolute',
+              left: 10,
+              top: 10,
+              width: 60,
+              height: 30,
+              backgroundColor: '#ff0000',
+            },
+            onMouseDown: log('legend'),
+          }),
+        ),
+      ),
+    { panes: 1 },
+  );
+  try {
+    const area = s.area();
+    const [legend] = area.children;
+    s.at(150, 150); // the surface
+    s.at(40, 25); // onto the legend's pane: a crossing into a child window
+    s.server.injectButton(1, true);
+    s.server.injectButton(1, false);
+    await waitFor(() => seen.some((e) => e.who === 'legend'), 'the press');
+    same(seen.find((e) => e.who === 'legend').target, legend, 'the press');
+    // it bubbled out through the surface, as out of any box
+    same(seen.find((e) => e.who === 'area')?.target, legend, 'bubbled');
+    seen.length = 0;
+    s.at(150, 150);
+    s.server.injectButton(1, true);
+    s.server.injectButton(1, false);
+    await waitFor(
+      () => seen.some((e) => e.who === 'area'),
+      'a press beside it',
+    );
+    same(seen.find((e) => e.who === 'area').target, area, 'a press beside');
+    assert.ok(!seen.some((e) => e.who === 'legend'));
+    assert.ok(
+      !seen.some((e) => e.who === 'window'),
+      'crossing onto a pane is not leaving the window',
+    );
+  } finally {
+    await s.close();
+  }
+});
+
+test('the children are drawn where GL is not, and are still the pointer’s', async () => {
+  const seen = [];
+  const s = await mount(
+    () =>
+      legendAndPanel({
+        onError: () => {},
+        onMouseDown: (ev) => seen.push(ev.target),
+      }),
+    { indirectContexts: false, panes: 2 },
+  );
+  try {
+    const area = s.area();
+    assert.ok(area.error, 'no GL surface on this server');
+    assert.ok(!area.window, 'no GL window');
+    const [legendPane] = area._overlay.panes;
+    near(await rgbOf(legendPane.wnd, 30, 15), RED, 'the legend, drawn');
+    // over a child: the child; between them, nothing covers the rect, and
+    // the tree behind answers
+    same(area.hitSurface(40, 25), area.children[0], 'over the legend');
+    same(area.hitSurface(150, 150), null, 'between the children');
+  } finally {
+    await s.close();
+  }
+});
+
+test('a hidden surface drops its panes, and a revealed one paints new ones', async () => {
+  const tree = (display) =>
+    h(
+      'window',
+      { width: 320, height: 240 },
+      h(
+        'box',
+        { style: { flexGrow: 1, display } },
+        legendAndPanel().props.children,
+      ),
+    );
+  const s = await mount(() => tree('flex'), { panes: 2 });
+  try {
+    const area = s.area();
+    await s.render(tree('none'));
+    await waitFor(() => area._overlay?.panes.length === 0, 'no panes');
+    await s.render(tree('flex'));
+    await waitFor(() => area._overlay?.panes.length === 2, 'panes again');
+    await settle(s.app);
+    near(await rgbOf(area._overlay.panes[0].wnd, 30, 15), RED, 'repainted');
+  } finally {
+    await s.close();
+  }
+});
+
+test("useSupports('glOverlay') is true on X11", async () => {
+  let answer = null;
+  function Probe() {
+    answer = useSupports('glOverlay');
+    return null;
+  }
+  const s = await mount(() =>
+    h(
+      'window',
+      { width: 320, height: 240 },
+      h('glarea', { style: { flexGrow: 1 }, onDraw: () => {} }),
+      h(Probe),
+    ),
+  );
+  try {
+    assert.equal(answer, true);
+  } finally {
+    await s.close();
+  }
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -799,6 +799,24 @@ declare const surfaceNode: GlAreaNode;
 const _forwardsPointer: true = surfaceNode.forwardsPointer;
 void _forwardsPointer;
 
+// a surface's children are 2D content drawn above it: laid out in its box
+// like a box's, and taking the pointer before it
+function Hud({ overlay }: { overlay: boolean }) {
+  return (
+    <glarea style={{ flexGrow: 1, padding: 12 }} onDraw={() => {}}>
+      {overlay && (
+        <box
+          style={{ position: 'absolute', left: 12, top: 12 }}
+          onMouseDown={(ev) => void ev.localX}
+        >
+          <text>Legend</text>
+        </box>
+      )}
+    </glarea>
+  );
+}
+void Hud;
+
 function Embedded({ id }: { id: number }) {
   return (
     <foreign
@@ -1277,15 +1295,17 @@ async function main() {
 
 // the things a display can be asked about, all plain booleans — about the
 // machine and the compositor, the backend this connection got, what that
-// backend draws controls with and whether it can host another app's window
+// backend draws controls with, whether it can host another app's window and
+// whether a <glarea>'s children are drawn above its surface
 function _Supports() {
   const canBlend: boolean = useSupports('transparency');
   const shaders: boolean = useSupports('shaders');
   const bezels: boolean = useSupports('nativeControls');
   const embedding: boolean = useSupports('embedding');
+  const overlay: boolean = useSupports('glOverlay');
   // @ts-expect-error — not a feature useSupports knows
   useSupports('webgpu');
-  void [canBlend, shaders, bezels, embedding];
+  void [canBlend, shaders, bezels, embedding, overlay];
   return null;
 }
 


### PR DESCRIPTION
The second upstream half of sidorares/react-x11-components#101 (a GL renderer behind `<Map>`): **2D content above a `<glarea>`.**

> **#545 is merged, and this applies directly on master as one commit.** Input over the children goes through #545's two rules: the surface-aware hit test, and the surface's window selecting no pointer input.

## Why

A `<glarea>` is stacked above every 2D thing in its window, so nothing could be drawn over a GL scene. `<Map>` has `children` (a legend, a control panel, laid out over the map), so it has to stay on its slow CPU renderer whenever an app passes any (`docs/prd-maps-gl.md`, "What GL needs before `'auto'` may choose it", item 5).

## The contract

- **`<glarea>`'s children are 2D content drawn above the surface.**
  - They're laid out in its box like a `<box>`'s (it's a flex container now) and cut to it.
  - They live in the owning window's tree like any box's children: its damage list, its event manager, its focus.
  - They're painted on **panes** stacked over the surface, in the owning window's frame and from its damage.
  - They take input before the surface. A press on a child is the child's; a press between the children is the `<glarea>`'s.
  - `pointerEvents: 'none'` on a child lets the pointer through to the surface.
- **`useSupports('glOverlay')`** is true where a connection draws them. Both backends do, and the headless mock too, since its windows take a child. It's a property of the backend and never changes. The element and the hook share one function (`canOverlay`), the way `<foreign>` and `'embedding'` share `canEmbed` since #543.
- The Reconciler's "`<glarea>` takes no children" rule is gone, along with `HostContext.isInside3d`.

| | Cocoa | X11 |
| --- | --- | --- |
| a pane | one transparent bitmap layer over the whole surface, at zPosition 1e7 + 1, just above the GL layer (`src/cocoa/overlay.js`, `app.createOverlayPane`) | one plain child window per region the children reach (each child's paint reach, overlapping ones merged), restacked directly above the surface's window |
| translucency | **composited** by Core Animation: a translucent fill, an antialiased edge or a shadow blends with the GL frame | **none**. A pane is opaque, and whatever a child leaves unpainted in its region shows the surface's `clearColor`, never the GL frame |
| input | the NSWindow's; the hit test asks the surface's children first | panes select nothing, so the pointer reaches the owning window by propagation (as in #545) and lands on the child |
| hidden, resize, scroll | panes follow the surface's rect each frame; hidden drops them, a reveal paints new ones | same; a pane that only moved keeps its pixels, a resized one is repainted whole, a lost backing (`draw`) is claimed back |

**Why regions and not SHAPE on X11.** A window cut to shape with the SHAPE extension is the other way to make a non-rectangular pane. Two things decided against it:
- SHAPE isn't universal. node-x11's in-process server has none, and that server is where this is tested.
- A single window as big as the surface keeps a backing pixmap the size of a map just to show a legend in its corner.

**X11 translucency** would need an ARGB child window blended by the server, which is untried and depends on the server's Composite behaviour. Say the word and I'll file it as a follow-up.

## What react-x11-components does to adopt it

- Render `<Map>`'s `children` **inside the `<glarea>`** when `useSupports('glOverlay')`, and drop "`children` keeps a map retained" from `renderer: 'auto'`'s gate.
- On X11 give the legend and control panels a background: they are opaque boxes over the map there, and a translucent one is tinted by `clearColor` rather than showing the map.
- Markers and attribution could be children too, but a marker per pane is a window per marker on X11; the PRD's plan to draw those in GL still stands.

## Verified

- **On a real X server** (Xvfb `:99`, `+iglx`, llvmpipe): `examples/labs/gl-overlay.jsx` rendered, captured with `xwd -root`. This is the server's own composite, so the GL frame and the panes above it are what the display shows. Four panes sit exactly at the four HUD boxes, and the card is opaque over the bars. Then a real click (XTEST) on "Hide legend" went through a pane to the button: the panes went from 4 to 3, and the bars show where the legend was.

  ![overlay-x11-xvfb](https://github.com/user-attachments/assets/8deb948a-faca-48ce-8e31-3a865df6b708)
  ![overlay-x11-xvfb-hidden](https://github.com/user-attachments/assets/cfcaef14-175e-4406-abf4-6a4e1847ff37)

- **On a real Cocoa window** (this Mac, scale 2): the same lab. Window capture does not see a GL layer, so this is a **reconstruction** (the lab's `LAB_SHOT`). The GL frame is read back with `readPixels` inside `onDraw`, and the window's and the overlay's own pixels are composited over it with straight alpha, the way the layers are. The tall bars show through the translucent card. The controls are drawn in AppKit's inactive-window style because the terminal kept focus.

  ![overlay-cocoa](https://github.com/user-attachments/assets/351b7d55-2d64-4aed-91f3-b3bf83524c21)

- **Harness** (`test/glarea-overlay.test.js`, in-process server and GLX emulator, 9 tests):
  - children laid out in the box
  - one pane per region, stacked above the GL window by the server's own `QueryTree`, even though the GL window is made after the panes
  - pane pixels read back, and nothing painted into the window's own backing
  - panes selecting no pointer input
  - a change repaints its own pane and no other
  - panes follow layout and go with their child; overlapping children share a pane, painted in order
  - a translucent fill blends with `clearColor` on X11
  - a press on a child versus beside it; crossing onto a pane is not a leave
  - children drawn and hittable when GL fails
  - hidden and revealed
  - `useSupports('glOverlay')`
- **Cocoa** (`test/cocoa-glarea.test.js`, fake bridge, 4 new tests):
  - the layer above the GL layer, exactly over it, device-sized, cleared rather than grounded, with every set made with implicit animations off
  - input at the child
  - **a child of the surface is never promoted** (its layer would sit under the GL layer), with an unpromoted sibling as the control
  - the layer goes with the last child
- **Mutation checks**, each planted in a scratch copy of `src/`. Every one turns the tests red:
  - pane sync removed from the frame: 9 tests fail
  - the surface not restacking its panes: the stacking test fails (the server's `QueryTree`)
  - the hit test skipping the children: two X11 tests and one Cocoa test fail
  - an opaque pane with no ground: the `clearColor` test fails
  - damage ignored, every pane repainted whole: the own-pane-only test fails
  - the promotion exclusion removed: the promotion test fails

  Two of these first said something about the tests rather than the code, and both are fixed here and in #545:
  - Tests handed nodes to `assert.equal`/`deepEqual`. A failed comparison `util.inspect`s the whole tree, so a caught regression stalled its file instead of failing it. Nodes are now compared by identity.
  - The promotion test first checked only `_promoted`, which a frame gets right either way. It now checks that the child's animation is never offered to a layer at the swap.
- `npm test`: 2435 of 2441 pass. The 6 failures are `test/appearance.test.js`, which fails identically on master here. `npm run typecheck`, `npm run lint` and `npm run format:check` pass. Benches:
  - protocol, run as `REACT_X11_BACKEND=x11 node --expose-gc … protocol.js --check`: "no regressions against the baseline". The darwin bootstrap relaunch rejects `--expose-gc` otherwise; CI's Linux job runs it the normal way.
  - pixels: "pixels unchanged".
  - presenters: every rule ok except `covered/surface`, which fails identically on master on this desktop.

## Limits, and the follow-ups they name

- **Overlapping surfaces.** Where two surfaces overlap, both overlays are above both frames on Cocoa (every GL layer shares zPosition 1e7). On X11 they stack by creation order.
- **Scroll panes.** A surface scrolled partly out of a scroll pane isn't clipped by it, and neither are its panes. This predates the overlay: the GL window never was clipped either.
- **Wasted passes on X11.** A claim inside the overlay also repaints the window's own pixels under the surface, which nobody sees. It's cheap (one small rect), and skipping passes wholly inside a surface is the follow-up.
- **Debug overlays.** The DevTools highlight and `REACT_X11_DEBUG_PAINT` draw in the window's pass, so they sit under a surface.

