### PR TITLE
fix(deps): take x11-dri 0.8 — ^0.7.0 stops short of it in 0.x semver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
       "optionalDependencies": {
         "@windowkit/appkit": "^0.10.0",
         "dbus-native": "^0.15.1",
-        "x11-dri": "^0.7.0"
+        "x11-dri": "^0.8.0"
       },
       "peerDependencies": {
         "@babel/core": "^8.0.0",
@@ -5333,9 +5333,9 @@
       }
     },
     "node_modules/x11-dri": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/x11-dri/-/x11-dri-0.7.0.tgz",
-      "integrity": "sha512-YRA62Q+MDMngeeKQ4Nx4N7zBO1xf7w9S1SXri+lJp4reAuusnVh1axy85qlBVFu3ft2KtjvqIMWY8NEaaln4SQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/x11-dri/-/x11-dri-0.8.0.tgz",
+      "integrity": "sha512-B1qXG76B+wMirRqetGtoToK9oDyVDSSgzzXCV/CeZEz8BZD0iGmntMhVKrQVgwoGGa5K/gbLdEwijnl1620Vjw==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
   "optionalDependencies": {
     "@windowkit/appkit": "^0.10.0",
     "dbus-native": "^0.15.1",
-    "x11-dri": "^0.7.0"
+    "x11-dri": "^0.8.0"
   },
   "peerDependencies": {
     "@babel/core": "^8.0.0",


### PR DESCRIPTION
## What

`optionalDependencies.x11-dri` goes from `^0.7.0` to `^0.8.0`, and the lockfile moves x11-dri from 0.7.0 to 0.8.0. That is the whole diff: 2 files, 5 lines. In `package.json` it is the spec; in `package-lock.json` it is the root's copy of the spec, plus the `node_modules/x11-dri` version, resolved URL and integrity.

## Why

In 0.x semver a caret stops at the next minor, so `^0.7.0` means `>=0.7.0 <0.8.0`. ntk's own range (`>=0.5.0 <1`) already admits 0.8, but npm installs one copy that satisfies both ranges, and that is 0.7.x. So no react-x11 app, `@react-x11/components` included, ever installs 0.8.

The components' GL map renderer (sidorares/react-x11-components#100) feature-detects `stencilOpSeparate` for a one-pass non-zero fill. Until this range moves it stays on the two-pass path. With this change, `npm ls x11-dri` shows one copy:

```
react-x11@2.12.0
+-- ntk@8.8.0
| `-- x11-dri@0.8.0 deduped
`-- x11-dri@0.8.0
```

## What 0.8 adds ([release notes](https://github.com/sidorares/node-x11-dri/releases/tag/v0.8.0))

- **Separate stencil state:** `stencilFuncSeparate`, `stencilOpSeparate` and `stencilMaskSeparate`. They are core in ES 2.0, so they are always present, with no flag (sidorares/node-x11-dri#23).
- **Multisampling:** `renderbufferStorageMultisample`, `blitFramebuffer` and `readBuffer`.
- **Sync objects:** `fenceSync`, `clientWaitSync` and the rest of that family.
- **GPU timer queries:** `beginQuery`/`endQuery`, `getQueryParameter` and `queryCounter`.
- Multisampling, sync objects and timer queries each sit behind a `features` flag.
- **Also in the release:**
  - `stencilSize` on `GpuOptions` (sidorares/node-x11-dri#25).
  - `Surface.resize()` with a `generation` counter (sidorares/node-x11-dri#26).
  - dma-buf import and map (sidorares/node-x11-dri#18).
  - The render node is now closed when the `Gpu` constructor throws (sidorares/node-x11-dri#28).

## Checked: nothing react-x11 uses has changed

I diffed the published 0.7.0 and 0.8.0 tarballs (`index.js`, `index.d.ts` and `src/x11dri.c`). The release is additive.

- **Cocoa (`src/cocoa/glarea.js`).** Every line it depends on is identical in both versions:
  - `apple.Context({ alphaSize, depthSize, stencilSize, doubleBuffer, profile })`
  - `makeCurrent`
  - `createTarget` and `bindTarget`
  - `refreshRate`
  - `gl` through `Object.create(dri.gl)`
- **ntk 8.8.0's direct paths.**
  - `new dri.Gpu({ format, depthSize, devicePath })` does not change. The new `stencilSize` defaults to 0, which is what 0.7's EGL config did implicitly: it never asked for stencil bits (sidorares/node-x11-dri#19).
  - `new dri.apple.Context({ depthSize })` does not change.
  - `surface.release(key)` still takes a bare key. It now returns a boolean, which ntk ignores.
  - ntk's `_installGL` copies every function on `dri.gl`, so the new entry points reach `onDraw` on X11 without any ntk change.
- **The one behaviour change.** `getParameter` now answers the stencil masks unsigned: all ones comes back as `4294967295`, not `-1`. Nothing in react-x11 reads those masks.
- **The 12 lines removed from the C source.** They are the internal `createGpu` arity (between `index.js` and the `.node` it ships with), some comments, and the extension candidate table.

Nothing else pins or documents the version:
- No CI workflow, `check:*` script, engines or peer note mentions it.
- The "(x11-dri >= 0.6)" note in `src/cocoa/glarea.js` is still true.
- The "x11-dri 0.6.0" in `docs/wayland.md` is that RFC's dated measurement, not a requirement.

## Tested (macOS, M1 Pro, Node 26)

- **GL tests:** `test/glarea`, `glarea-overlay`, `cocoa-glarea`, `viewer3d` and `gl-supports` — 38/38 pass.
- **`npm test -- --test-reporter=spec`:** 2435/2441 pass. The 6 failures are all in `test/appearance.test.js`. This machine reports dark mode, so they fail here on master too.
- **`npm run lint`, `npm run format:check`, `npm run typecheck`:** all clean.
- **Direct-GL smoke test on XQuartz** (`REACT_X11_BACKEND=x11`, `createRoot({ glPolicy: 'auto' })`):
  - `glCapabilities()` reports direct GL, flavor `appledri`, and `gl.backend` is `'direct'`.
  - A `<glarea>` cleared to (0.2, 0.4, 0.8), and `gl.readPixels` in `onDraw` returned `[51, 102, 204, 255]`.
  - `typeof gl.stencilOpSeparate === 'function'`.
  - `stencilOpSeparate(FRONT, KEEP, KEEP, INCR_WRAP)` raises no GL error. `getParameter` then reads `INCR_WRAP` for the front zpass op and `KEEP` for the back one.
  - `features` has `multisample`, `readBuffer`, `sync`, `timerQuery` and `timestampQuery` all true. `dmabufImport` is false, as expected on CGL.

## Release

Release PR #544 (2.13.0) is still open. If this merges before it, the bump ships in 2.13.0.
