### PR TITLE
test(screencolor): the suite stays off the developer's session bus — a stray pick opened GNOME's real picker

### DIFF
--- a/test/helpers/with-bus.js
+++ b/test/helpers/with-bus.js
@@ -14,9 +14,27 @@
 // longer closes the socket, so without it a connection would survive between
 // tests carrying match rules and exported objects. That is the harness
 // closing what the harness caused, not a seam into production code.
+//
+// **Neither helper covers anything outside `fn`.** A call made after one
+// returns — or by an effect or a timer that fires later — reads the
+// process's own environment, and on a logged-in desktop that is the real
+// session bus with the real portal on it. CI has no session bus, so such a
+// test stays green there and misbehaves only on a developer's machine. The
+// eyedropper suite had one: a pick one line below `withNoBus` found GNOME's
+// Screenshot portal, the shell put its colour picker on the screen, and the
+// file hung waiting for a click — and while that request stayed open, later
+// runs were refused with "There is an ongoing operation for this sender".
+// `offTheDesktopBus()` at the top of a file takes all of it off the
+// developer's bus, so a dial that slips out finds nothing.
+
+import { after, before } from 'node:test';
 
 import { _resetBusState, closeBus } from '../../src/bus.js';
 import { _resetServiceCache } from '../../src/portal.js';
+
+/** An address that names nothing: where `withNoBus()` and
+ *  `offTheDesktopBus()` point the session bus. */
+const NO_BUS = 'unix:path=/nonexistent/no-bus-here';
 
 /**
  * The transport, loaded on demand — this file is imported by a suite that has
@@ -83,6 +101,10 @@ function restore(name, value) {
  * and a test that skipped this on a developer's own desktop would reach the
  * real portal and put a dialog on their screen, then wait for a human. That
  * is exactly what happened while writing the file-dialog tests.
+ *
+ * **And only inside `fn`.** The environment goes back on the way out, so an
+ * assertion that still needs "no bus here" — a second pick, a late probe —
+ * belongs inside the callback, not on the line after it.
  */
 export async function withNoBus(fn) {
   const saved = {
@@ -93,7 +115,7 @@ export async function withNoBus(fn) {
   await closeBus('session').catch(() => {});
   _resetBusState();
   _resetServiceCache();
-  process.env.DBUS_SESSION_BUS_ADDRESS = 'unix:path=/nonexistent/no-bus-here';
+  process.env.DBUS_SESSION_BUS_ADDRESS = NO_BUS;
   delete process.env.XDG_RUNTIME_DIR;
   Object.defineProperty(process, 'platform', { value: 'linux' });
   try {
@@ -109,6 +131,46 @@ export async function withNoBus(fn) {
     _resetBusState();
     _resetServiceCache();
   }
+}
+
+/**
+ * Take a whole file off the developer's session bus.
+ *
+ * ```js
+ * offTheDesktopBus(); // at the top level of a test file, once
+ * ```
+ *
+ * From the first test to the last, `DBUS_SESSION_BUS_ADDRESS` names nothing
+ * and `XDG_RUNTIME_DIR` is gone, so a dial that slips out of `withBus()` or
+ * `withNoBus()` finds no bus — the answer CI gives — rather than the desktop
+ * the suite happens to be running on. Both helpers still work under it: each
+ * saves what it finds, which is now this, and puts that back.
+ *
+ * The session bus only, since it is the one with a portal on it — the one
+ * that can put a dialog on the screen and wait for a human.
+ */
+export function offTheDesktopBus() {
+  const saved = {};
+  before(async () => {
+    saved.address = process.env.DBUS_SESSION_BUS_ADDRESS;
+    saved.runtime = process.env.XDG_RUNTIME_DIR;
+    // Closed first, for withNoBus()'s reason: a live connection is handed
+    // back whatever the environment says now.
+    await closeBus('session').catch(() => {});
+    _resetBusState();
+    _resetServiceCache();
+    process.env.DBUS_SESSION_BUS_ADDRESS = NO_BUS;
+    // src/bus.js falls back to `$XDG_RUNTIME_DIR/bus` when the address is
+    // unset, and on a desktop that is the real bus again.
+    delete process.env.XDG_RUNTIME_DIR;
+  });
+  after(async () => {
+    restore('DBUS_SESSION_BUS_ADDRESS', saved.address);
+    restore('XDG_RUNTIME_DIR', saved.runtime);
+    await closeBus('session').catch(() => {});
+    _resetBusState();
+    _resetServiceCache();
+  });
 }
 
 /** A listening broker, with a live client count attached. */

--- a/test/screencolor.test.js
+++ b/test/screencolor.test.js
@@ -25,6 +25,7 @@ import { useEyedropper } from '../src/screencolorhooks.js';
 import { act, cleanup, fireEvent, renderX11 } from '../src/testing/index.js';
 import { fakePortal } from './helpers/fake-portal.js';
 import {
+  offTheDesktopBus,
   transportAvailable,
   until,
   withBus,
@@ -35,6 +36,13 @@ const haveTransport = await transportAvailable();
 const needsBroker = haveTransport
   ? {}
   : { skip: 'dbus-native is not installed (expected on Node < 22.12)' };
+
+// **Nothing here may reach the developer's own session bus.** Where the
+// portal has Screenshot v2 — GNOME, KDE — the portal rung is a real
+// PickColor, so a pick that slips out of `withNoBus` puts the shell's picker
+// on the screen and hangs the file waiting for a click. The whole file runs
+// with no bus, as CI does, and `withBus()` is the only way onto one.
+offTheDesktopBus();
 
 afterEach(() => {
   _resetServiceCache();
@@ -638,10 +646,17 @@ describe('useEyedropper', () => {
       await act(async () => {
         await new Promise((r) => setTimeout(r, 30));
       });
+      assert.equal(eyedropper.supported, false);
+      // And the pick a test or a keyboard shortcut can still reach rejects
+      // typed rather than throwing a TypeError from inside the promise.
+      //
+      // Inside the block, not after it: `pick()` climbs the ladder from the
+      // top again rather than trusting `supported`, so it needs "no bus
+      // here" as much as the probe did. It once sat one line below, where
+      // the developer's own bus was back — on GNOME, a real PickColor: the
+      // shell's picker on the screen, waiting for a click the suite could
+      // not give.
+      await assert.rejects(() => eyedropper.pick(), NoScreenColorError);
     });
-    assert.equal(eyedropper.supported, false);
-    // And the pick a test or a keyboard shortcut can still reach rejects
-    // typed rather than throwing a TypeError from inside the promise.
-    await assert.rejects(() => eyedropper.pick(), NoScreenColorError);
   });
 });


### PR DESCRIPTION
## Summary

On a GNOME desktop, `test/screencolor.test.js` put the shell's colour picker on the screen and hung. The `useEyedropper › a tree whose connection cannot grab is not supported` case called `eyedropper.pick()` one line after its `withNoBus` block had returned, when the environment was the developer's own again. `pick()` climbs the ladder from the top rather than trusting `supported`, so the portal rung found xdg-desktop-portal-gnome's Screenshot interface at version 2 and made a real `PickColor`, waiting for a click the suite could not give. The pending request keeps the bus socket ref'd, so the file never exits.

While that request stayed open, later runs were refused with "There is an ongoing operation for this sender". The ladder reads that as a cancel, so the pick resolved to `null` and the test failed with "Missing expected rejection". CI has no session bus, so it stayed green there.

## Changes

- **`test/screencolor.test.js`**: the pick and its `supported` check run inside `withNoBus`, and the file calls `offTheDesktopBus()` at its top level.
- **`test/helpers/with-bus.js`**: a new `offTheDesktopBus()`, a pair of `before`/`after` hooks that point `DBUS_SESSION_BUS_ADDRESS` at a nonexistent socket and remove `XDG_RUNTIME_DIR` for the whole file. A dial that slips out of `withBus()`/`withNoBus()` then finds no bus, which is CI's answer, instead of the desktop. Both helpers work unchanged under it. The header documents the hazard, and `withNoBus()`'s doc says an assertion that needs "no bus" belongs inside the callback.

## How it was found and verified

Nothing was run with the real bus reachable.

- Every `dbus-native` `createClient()` was traced through a `--require` preload while the process's own address was a fake one, distinct from `withNoBus`'s. The pick was the only dial to it.
- The hang was reproduced against a fake desktop: a private broker exported as the process bus, with a Screenshot v2 portal whose `PickColor` never answers.

| Run | Result |
|---|---|
| Unfixed file, fake desktop | 1 `PickColor`, test timeout, process hung until killed |
| Pick moved inside, no guard | 23/23, no connection to the fake desktop |
| Guard only, pick put back outside | 23/23, no connection to the fake desktop |
| This branch, fake desktop | 23/23, no connection to the fake desktop |
| The 11 other suites importing `with-bus.js`, fake address | 273/273 |

The first three runs were on `claude/wayland-backend-prd-5cb4fc`'s tree, where both files are identical to master; the last two on this branch. Prettier and ESLint are clean on both files.

## Not in this PR

The same trace caught two more dials to the process's own bus: `fileDialogBackend()` unguarded in `test/filedialog.test.js` ("the ladder"), and `src/atspi.js`'s AT-SPI discovery probe in suites that call `createRoot()` without the test harness, which is what sets `NO_AT_BRIDGE=1`. Neither shows a dialog. They are a separate change.

The two touched files are identical on the Wayland branch (#548), so this lands there without conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
