### PR TITLE
test: three more suites stay off the developer's session bus — a bare portal probe and two AT-SPI climbs reached the desktop

### DIFF
--- a/test/cocoa-screencolor.test.js
+++ b/test/cocoa-screencolor.test.js
@@ -38,6 +38,7 @@ import { setScaleForTests } from '../src/scale.js';
 import { setScreensForTests } from '../src/screens.js';
 import { fakePortal } from './helpers/fake-portal.js';
 import {
+  offTheDesktopBus,
   transportAvailable,
   until,
   withBus,
@@ -51,6 +52,16 @@ const haveTransport = await transportAvailable();
 const needsBroker = haveTransport
   ? {}
   : { skip: 'dbus-native is not installed (expected on Node < 22.12)' };
+
+// **Nothing here may reach the developer's own desktop.** A root built with
+// `createRoot()` rather than through `react-x11/test` starts the AT-SPI
+// bridge as an app's would, climbing toward the desktop's accessibility
+// registry — so it is off here, as the harness has it. And the whole file
+// runs with no session bus, as CI does: under the sampler is the portal
+// rung, a real PickColor wherever the portal has Screenshot v2, and a bare
+// `pickScreenColor()` falls through to it if the cocoa rung stops answering.
+process.env.NO_AT_BRIDGE ??= '1';
+offTheDesktopBus();
 
 /** The loupe is up and the user has not answered it — the state AppKit gives
  *  no way out of from code, and the one an abort has to survive. */

--- a/test/desktop-calendar.test.js
+++ b/test/desktop-calendar.test.js
@@ -46,7 +46,12 @@ import { setScreensForTests } from '../src/screens.js';
 import { _resetBusState } from '../src/bus.js';
 import { _resetServiceCache } from '../src/portal.js';
 import { fakeEds, NOTIFY_INITIAL } from './helpers/fake-eds.js';
-import { transportAvailable, withBus, withNoBus } from './helpers/with-bus.js';
+import {
+  offTheDesktopBus,
+  transportAvailable,
+  withBus,
+  withNoBus,
+} from './helpers/with-bus.js';
 
 const h = React.createElement;
 const tick = () => new Promise((resolve) => setTimeout(resolve, 2));
@@ -55,6 +60,16 @@ const haveTransport = await transportAvailable();
 const needsBroker = haveTransport
   ? {}
   : { skip: 'dbus-native is not installed (expected on Node < 22.12)' };
+
+// **Nothing here may reach the developer's own desktop.** A root built with
+// `createRoot()` rather than through `react-x11/test` starts the AT-SPI
+// bridge as an app's would, climbing toward the desktop's accessibility
+// registry — so it is off here, as the harness has it. And the whole file
+// runs with no session bus, as CI does: on a desktop the EDS rung is the
+// developer's own calendars, and a ladder that slips out of
+// `withBus`/`withNoBus` would read them.
+process.env.NO_AT_BRIDGE ??= '1';
+offTheDesktopBus();
 
 /** Poll until `check` answers, flushing timers and microtasks between tries.
  *  Every rung here settles across ticks — a bus round trip, a pipe, a

--- a/test/filedialog.test.js
+++ b/test/filedialog.test.js
@@ -41,6 +41,7 @@ import {
 } from '../src/testing/index.js';
 import { fakePortal } from './helpers/fake-portal.js';
 import {
+  offTheDesktopBus,
   transportAvailable,
   until,
   withBus,
@@ -51,6 +52,15 @@ const haveTransport = await transportAvailable();
 const needsBroker = haveTransport
   ? {}
   : { skip: 'dbus-native is not installed (expected on Node < 22.12)' };
+
+// **Nothing here may reach the developer's own session bus.** On a desktop
+// the portal rung is the real FileChooser, and a call that slips out of
+// `withBus`/`withNoBus` finds it: an open puts a dialog on the screen and
+// waits for a human, as one did while this file was being written. The
+// ladder's backend probe was such a call — it ran bare, and answered for
+// whichever desktop the suite happened to run on. The whole file runs with
+// no bus, as CI does, and `withBus()` is the only way onto one.
+offTheDesktopBus();
 
 afterEach(() => {
   _resetServiceCache();


### PR DESCRIPTION
Follows #549, which added `offTheDesktopBus()` after the eyedropper suite put GNOME's real colour picker on the screen. Tracing the other suites the same way found three more tests that dial the developer's own session bus from outside `withBus()`/`withNoBus()`. CI has no session bus, so all three are green there; on a desktop they reach the real portal and the real AT-SPI bus.

## What the trace found

Every dbus-native `createClient()` was logged, charged to the test whose async context made it, while the process's own `DBUS_SESSION_BUS_ADDRESS` was a fake address distinct from `withNoBus`'s (with `XDG_RUNTIME_DIR` empty and no display). A dial to that address is one that would have reached the real bus. Five runs, the same three every time:

| Suite | Test | What dialled |
|---|---|---|
| `test/filedialog.test.js` | the ladder › backend selection is reported without showing anything | `fileDialogBackend()`, run bare: it probed the desktop's real FileChooser portal |
| `test/cocoa-screencolor.test.js` | the ladder reaches the system sampler › a showing cocoa root answers a bare `pickScreenColor()` | the file's first `createRoot()`, starting the AT-SPI bridge |
| `test/desktop-calendar.test.js` | useDesktopCalendarEvents › it settles on ready, grouped the way a grid asks | the file's first `createRoot()`, starting the AT-SPI bridge |

The two AT-SPI suites build roots with `createRoot()` rather than through `src/testing`, whose harness is what sets `NO_AT_BRIDGE=1`. `test/notifications.test.js` and `test/appearance.test.js` were traced too and are clean: the first gets `NO_AT_BRIDGE` through `test/helpers/mock-app.js` (a re-export of `src/testing/mock-app.js`), and the second's own `withNoBus` covers its dials.

## The fix

- All three files call `offTheDesktopBus()` at their top level, as `test/screencolor.test.js` does since #549.
- The two AT-SPI suites also set `process.env.NO_AT_BRIDGE ??= '1'`, the line the other cocoa suites already carry. It stops the climb before it dials anything. The bus guard covers what it can't: the portal and EDS rungs those files fall through to if the cocoa rung stops answering, and a climb forced back on with `REACT_X11_A11Y=1`.

No change to the helper.

## Verification

All under a fake process bus address, an empty `XDG_RUNTIME_DIR` and no display:

- The five suites: 166/166, traced four times with no dial to the process address, and 166/166 untraced.
- `REACT_X11_A11Y=1` (which overrides `NO_AT_BRIDGE`) on the two AT-SPI suites: 55/55, and the climb reaches only `withNoBus`'s nonexistent socket, so the guard holds on its own.
- Prettier leaves the files unchanged; ESLint is clean.

## Not covered

An exported `AT_SPI_BUS_ADDRESS` (Flatpak sets one) overrides `NO_AT_BRIDGE` and goes straight to the accessibility bus without touching the session bus, so neither guard stops it. That is from reading `a11yEnabled()` in `src/a11y.js`; not tried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
